### PR TITLE
feat: Update design token & Integrate color to TailwindCSS configuration

### DIFF
--- a/nextjs-app/app/dev-only/tailwind-demo/page.tsx
+++ b/nextjs-app/app/dev-only/tailwind-demo/page.tsx
@@ -6,21 +6,25 @@ export default async function TailwindDemo() {
       <hr className="mb-10" />
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Breakpoints</h2>
+        <h2 className="text-h3 text-blue-5">Breakpoints</h2>
 
         <p>
           Background color will change when the screen size is changed.
           <br />
-          <span className="text-red-500">Try to change the screen size.</span>
+          <span className="text-blue-5">Try to change the screen size.</span>
         </p>
 
-        <div className="w-[100px] h-[100px] bg-blue-500 md:bg-red-500 lg:bg-green-500 xl:bg-yellow-500"></div>
+        <div className="w-[100px] h-[100px] bg-blue-5 md:bg-neutral-6 lg:bg-yellow-5 xl:bg-yellow-2"></div>
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Typography</h2>
+        <h2 className="text-h3 text-blue-6">Typography</h2>
 
         <ol>
+          <li className="text-h1-title">H1 Title</li>
+          <li className="text-h2-title">H2 Title</li>
+          <li className="text-h3-title">H3 Title</li>
+          <li className="text-h4-title">H4 Title</li>
           <li className="text-h1">H1</li>
           <li className="text-h2">H2</li>
           <li className="text-h3">H3</li>
@@ -36,26 +40,21 @@ export default async function TailwindDemo() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Font Size</h2>
+        <h2 className="text-h3 text-blue-6">Font Size</h2>
 
-        <ol>
-          <li className="text-1">Text-1</li>
-          <li className="text-2">Text-2</li>
-          <li className="text-3">Text-3</li>
-          <li className="text-4">Text-4</li>
-          <li className="text-5">Text-5</li>
-          <li className="text-6">Text-6</li>
-          <li className="text-7">Text-7</li>
-          <li className="text-8">Text-8</li>
-          <li className="text-9">Text-9</li>
-        </ol>
+        {Array.from({ length: 9 }, (_, i) => i + 1).map((num) => (
+          <li key={num} className={`text-${num.toString()}`}>
+            Text-{num}
+          </li>
+        ))}
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Font Weight</h2>
+        <h2 className="text-h3 text-blue-6">Font Weight</h2>
 
         <ol>
           <li className="font-bold">font-weight-bold</li>
+          <li className="font-semibold">font-weight-semibold</li>
           <li className="font-medium">font-weight-medium</li>
           <li className="font-regular">font-weight-regular</li>
           <li className="font-light">font-weight-light</li>
@@ -63,103 +62,49 @@ export default async function TailwindDemo() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Line Height</h2>
+        <h2 className="text-h3 text-blue-6">Line Height</h2>
 
         <ol>
-          <li className="leading-1">line height 1</li>
-          <li className="leading-2">line height 2</li>
-          <li className="leading-3">line height 3</li>
-          <li className="leading-4">line height 4</li>
-          <li className="leading-5">line height 5</li>
-          <li className="leading-6">line height 6</li>
-          <li className="leading-7">line height 7</li>
-          <li className="leading-8">line height 8</li>
-          <li className="leading-9">line height 9</li>
-          <li className="leading-10">line height 10</li>
-          <li className="leading-11">line height 11</li>
+          {Array.from({ length: 11 }, (_, i) => i + 1).map((lineHeight) => (
+            <li key={lineHeight} className={`leading-${lineHeight.toString()}`}>
+              line height {lineHeight}
+            </li>
+          ))}
         </ol>
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Spacing</h2>
+        <h2 className="text-h3 text-blue-6">Spacing</h2>
 
         <ol>
-          <li>
-            <p>space-1</p>
-            <div className="h-5 pl-1 bg-sky-400 inline-block"></div>
-          </li>
-          <li>
-            <p>space-2</p>
-            <div className="h-5 pl-2 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-3</p>
-            <div className="h-5 pl-3 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-4</p>
-            <div className="h-5 pl-4 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-5</p>
-            <div className="h-5 pl-5 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-6</p>
-            <div className="h-5 pl-6 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-7</p>
-            <div className="h-5 pl-7 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-8</p>
-            <div className="h-5 pl-8 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-9</p>
-            <div className="h-5 pl-9 bg-sky-400 inline-block "></div>
-          </li>
-          <li>
-            <p>space-10</p>
-            <div className="h-5 pl-10 bg-sky-400 inline-block "></div>
-          </li>
+          {Array.from({ length: 11 }, (_, i) => i + 1).map((space) => (
+            <li key={`space-${space.toString()}`}>
+              <p>space-{space}</p>
+              <div
+                className={`h-5 pl-${space.toString()} bg-blue-4 inline-block`}
+              ></div>
+            </li>
+          ))}
         </ol>
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Border Radius</h2>
+        <h2 className="text-h3 text-blue-6">Border Radius</h2>
 
         <ol>
-          <li className="mb-6">
-            <p>rounded-1</p>
-            <div className="rounded-1 bg-blue-500 p-[50px] inline-block"></div>
-          </li>
-          <li className="mb-6">
-            <p>rounded-2</p>
-            <div className="rounded-2 bg-blue-500 p-[50px] inline-block"></div>
-          </li>
-          <li className="mb-6">
-            <p>rounded-3</p>
-            <div className="rounded-3 bg-blue-500 p-[50px] inline-block"></div>
-          </li>
-          <li className="mb-6">
-            <p>rounded-4</p>
-            <div className="rounded-4 bg-blue-500 p-[50px] inline-block"></div>
-          </li>
-          <li className="mb-6">
-            <p>rounded-circle</p>
-            <div className="rounded-circle bg-blue-500 p-[50px] inline-block"></div>
-          </li>
-          <li className="mb-6">
-            <p>rounded-pill</p>
-            <div className="rounded-pill bg-blue-500 p-[50px] inline-block"></div>
-          </li>
+          {["1", "2", "3", "4", "circle", "pill"].map((rounded) => (
+            <li key={rounded} className="mb-6">
+              <p>rounded-{rounded}</p>
+              <div
+                className={`rounded-${rounded} bg-yellow-3 p-[50px] inline-block`}
+              ></div>
+            </li>
+          ))}
         </ol>
       </section>
 
       <section className="mb-10">
-        <h2 className="text-h3 text-blue-600">Box Shadow</h2>
+        <h2 className="text-h3 text-blue-6">Box Shadow</h2>
 
         <ol>
           <li className="mb-6">

--- a/nextjs-app/design-system/data/token.json
+++ b/nextjs-app/design-system/data/token.json
@@ -378,5 +378,139 @@
       "value": "56px",
       "type": "other"
     }
+  },
+  "white": {
+    "value": "#FFFFFF",
+    "type": "color"
+  },
+  "black": {
+    "value": "#000000",
+    "type": "color"
+  },
+  "neutral": {
+    "1": {
+      "value": "#F4F4F4",
+      "type": "color"
+    },
+    "2": {
+      "value": "#E9E9EA",
+      "type": "color"
+    },
+    "3": {
+      "value": "#D4D4D4",
+      "type": "color"
+    },
+    "4": {
+      "value": "#B3B7BD",
+      "type": "color"
+    },
+    "5": {
+      "value": "#949BA5",
+      "type": "color"
+    },
+    "6": {
+      "value": "#78818E",
+      "type": "color"
+    },
+    "7": {
+      "value": "#5E6876",
+      "type": "color"
+    },
+    "8": {
+      "value": "#47515F",
+      "type": "color"
+    },
+    "9": {
+      "value": "#323B47",
+      "type": "color"
+    },
+    "10": {
+      "value": "#1F2630",
+      "type": "color"
+    }
+  },
+  "yellow": {
+    "1": {
+      "value": "#F8F5F2",
+      "type": "color"
+    },
+    "2": {
+      "value": "#D9CFBF",
+      "type": "color"
+    },
+    "3": {
+      "value": "#C9BCA7",
+      "type": "color"
+    },
+    "4": {
+      "value": "#B5A68D",
+      "type": "color"
+    },
+    "5": {
+      "value": "#91826A",
+      "type": "color"
+    },
+    "6": {
+      "value": "#7E7059",
+      "type": "color"
+    },
+    "7": {
+      "value": "#7B6748",
+      "type": "color"
+    },
+    "8": {
+      "value": "#735B35",
+      "type": "color"
+    },
+    "9": {
+      "value": "#684D22",
+      "type": "color"
+    },
+    "10": {
+      "value": "#684D22",
+      "type": "color"
+    }
+  },
+  "blue": {
+    "1": {
+      "value": "#F4F6FA",
+      "type": "color"
+    },
+    "2": {
+      "value": "#E1E3F2",
+      "type": "color"
+    },
+    "3": {
+      "value": "#C5C8E5",
+      "type": "color"
+    },
+    "4": {
+      "value": "#AAAFD9",
+      "type": "color"
+    },
+    "5": {
+      "value": "#525AA4",
+      "type": "color"
+    },
+    "6": {
+      "value": "#202870",
+      "type": "color"
+    },
+    "7": {
+      "value": "#131956",
+      "type": "color"
+    },
+    "8": {
+      "value": "#090E3E",
+      "type": "color"
+    },
+    "9": {
+      "value": "#00063A",
+      "type": "color"
+    },
+    "10": {
+      "value": "#00042C",
+      "type": "color"
+    }
   }
 }

--- a/nextjs-app/design-system/data/token.json
+++ b/nextjs-app/design-system/data/token.json
@@ -140,7 +140,7 @@
       "value": {
         "x": "0",
         "y": "0",
-        "blur": "9",
+        "blur": "8px",
         "spread": "0",
         "color": "rgba(37, 42, 49,0.16)",
         "type": "innerShadow"
@@ -221,14 +221,50 @@
     "10": {
       "value": "48px",
       "type": "spacing"
+    },
+    "11": {
+      "value": "56px",
+      "type": "spacing"
     }
   },
   "typography": {
-    "h1": {
+    "h1-title": {
       "value": {
         "lineHeight": "48px",
-        "fontSize": "32px",
-        "fontWeight": 500
+        "fontSize": "48px",
+        "fontWeight": 600
+      },
+      "type": "typography"
+    },
+    "h2-title": {
+      "value": {
+        "lineHeight": "40px",
+        "fontSize": "40px",
+        "fontWeight": 600
+      },
+      "type": "typography"
+    },
+    "h3-title": {
+      "value": {
+        "lineHeight": "36px",
+        "fontSize": "36px",
+        "fontWeight": 600
+      },
+      "type": "typography"
+    },
+    "h4-title": {
+      "value": {
+        "lineHeight": "24px",
+        "fontSize": "22px",
+        "fontWeight": 400
+      },
+      "type": "typography"
+    },
+    "h1": {
+      "value": {
+        "lineHeight": "52px",
+        "fontSize": "40px",
+        "fontWeight": 700
       },
       "type": "typography"
     },
@@ -236,7 +272,7 @@
       "value": {
         "lineHeight": "44px",
         "fontSize": "28px",
-        "fontWeight": 500
+        "fontWeight": 700
       },
       "type": "typography"
     },
@@ -336,6 +372,10 @@
     },
     "6": {
       "value": "48px",
+      "type": "other"
+    },
+    "7": {
+      "value": "56px",
       "type": "other"
     }
   }

--- a/nextjs-app/design-system/util/transferTokenToTailwindStyles.ts
+++ b/nextjs-app/design-system/util/transferTokenToTailwindStyles.ts
@@ -61,6 +61,11 @@ const transferTokenToTailwindStyles = (token: TokenType) => {
     radius: radiusToken,
     spacing: spacingToken,
     boxShadow: boxShadowToken,
+    white: colorWhiteToken,
+    black: colorBlackToken,
+    neutral: colorNeutralToken,
+    yellow: colorYellowToken,
+    blue: colorBlueToken,
   } = token;
 
   const fontSize = convertProperty(fontSizesToken);
@@ -71,6 +76,16 @@ const transferTokenToTailwindStyles = (token: TokenType) => {
   const spacing = convertProperty(spacingToken);
   const boxShadow = convertShadowProperty(boxShadowToken);
 
+  const colors = {
+    transparent: "transparent",
+    current: "currentColor",
+    white: colorWhiteToken.value,
+    black: colorBlackToken.value,
+    neutral: convertProperty(colorNeutralToken),
+    yellow: convertProperty(colorYellowToken),
+    blue: convertProperty(colorBlueToken),
+  };
+
   return {
     fontSize,
     fontWeight,
@@ -79,6 +94,7 @@ const transferTokenToTailwindStyles = (token: TokenType) => {
     borderRadius,
     spacing,
     boxShadow,
+    colors,
   };
 };
 

--- a/nextjs-app/tailwind.config.ts
+++ b/nextjs-app/tailwind.config.ts
@@ -11,6 +11,7 @@ const {
   borderRadius,
   spacing,
   boxShadow,
+  colors,
 } = transferTokenToTailwindStyles(token);
 
 export default {
@@ -38,6 +39,7 @@ export default {
         "sans-serif",
       ],
     },
+    colors,
     extend: {
       fontWeight,
       lineHeight,


### PR DESCRIPTION
## Why need this change? / Root cause:

- close https://github.com/thementorship-tw/thementorship.tw/issues/24

## Changes made:

- [b1c661c](https://github.com/thementorship-tw/thementorship.tw/pull/36/commits/b1c661cf8782b991000888889d511b59d9d00bdc): Update Design token (notion last updated at 2025/01/05 - [link](https://www.notion.so/Design-Token-1613af684bf880aa9e36d70db972e487))
- [3bf6041](https://github.com/thementorship-tw/thementorship.tw/pull/36/commits/3bf6041b4abe4b69795892d608d213e82d211a17), [3bf6041](https://github.com/thementorship-tw/thementorship.tw/pull/36/commits/3bf6041b4abe4b69795892d608d213e82d211a17) : Integrate design tokens for color 
  - reference : https://tailwindcss.com/docs/customizing-colors#color-object-syntax
- [5f06ed2](https://github.com/thementorship-tw/thementorship.tw/pull/36/commits/5f06ed20009ab871785a2dc4b4b7443f7c10643e) : Update demo page `/dev-only/tailwind-demo`

## Test Scope / Change impact:

Tailwind Config Usage Guide

- Color

  these colors will be made available everywhere in the framework where you use colors, 
  like the **text color** utilities, **border color** utilities, **background color** utilities.
  
  ex :
    - `text-blue-2`
    - `bg-blue-6`
    - `border-blue-6`
