### PR TITLE
feat: breadcrumb common component

### DIFF
--- a/nextjs-app/app/faq/page.tsx
+++ b/nextjs-app/app/faq/page.tsx
@@ -1,9 +1,14 @@
 import type { Metadata } from "next";
+import Breadcrumb from "@/components/common/Breadcrumb";
 
 export const metadata: Metadata = {
   title: "常見問題",
 };
 
 export default async function FAQPage() {
-  return <div>FAQ page</div>;
+  return (
+    <div>
+      <Breadcrumb items={["HOME", "常見問題"]} />
+    </div>
+  );
 }

--- a/nextjs-app/app/not-found.tsx
+++ b/nextjs-app/app/not-found.tsx
@@ -11,7 +11,7 @@ export default async function NotFoundPage() {
           height={120}
           className="mb-5"
         />
-        <div className="text-h5 font-['PingFang_TC']">Page Not Found</div>
+        <div className="text-h5 font-semibold text-blue-8">Page Not Found</div>
       </div>
     </div>
   );

--- a/nextjs-app/components/common/Breadcrumb.tsx
+++ b/nextjs-app/components/common/Breadcrumb.tsx
@@ -1,0 +1,28 @@
+import { FC } from "react";
+
+interface IBreadcrumbProps {
+  items: string[];
+}
+
+const Breadcrumb: FC<IBreadcrumbProps> = ({ items }) => {
+  return (
+    <nav className="p-5 md:px-7 max-h-10">
+      <ol className="flex items-center">
+        {items.map((item, idx) => (
+          <li key={item} className="flex items-center">
+            <span
+              className={`text-body-sm ${idx === 0 ? "text-yellow-6" : "text-neutral-10"}`}
+            >
+              {item}
+            </span>
+            {idx < items.length - 1 && (
+              <div className="mx-3 w-3 h-[1px] bg-yellow-6" />
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumb;

--- a/nextjs-app/components/pages/main/StayUpdated.tsx
+++ b/nextjs-app/components/pages/main/StayUpdated.tsx
@@ -80,7 +80,7 @@ const StayUpdated = () => {
               className="border w-[156px] h-[92px] md:w-[212px] md:h-[212px] rounded-3 hover:bg-[#F8F5F2] transition-all duration-300 border-[#7E7059] flex items-center justify-center"
             >
               <div className="flex flex-col items-center gap-2 md:gap-4">
-                <span className="text-xl font-semibold text-[#1F2630] font-['PingFang_TC']">
+                <span className="text-xl font-semibold text-[#1F2630]">
                   {link.name}
                 </span>
                 <span className="text-3xl">{link.icon}</span>


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #40 
- breadcrumb component
- remove all `PingFang_TC` font family

<img width="624" alt="截圖 2025-01-11 凌晨12 17 41" src="https://github.com/user-attachments/assets/0285af07-5f97-4157-b570-2fd6a3c00ccd" />


## Changes made:

-

## Test Scope / Change impact:

-
