### PR TITLE
feat: page title with animated text (marquee effect)

### DIFF
--- a/nextjs-app/app/about/overview/page.tsx
+++ b/nextjs-app/app/about/overview/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from "next";
+import Breadcrumb from "@/components/common/Breadcrumb";
+import MarqueeTitle from "@/components/common/MarqueeTitle";
 
 export const metadata: Metadata = {
   title: "計畫介紹",
 };
 
 export default async function OverviewPage() {
-  return <div>計畫介紹</div>;
+  return (
+    <div>
+      <Breadcrumb items={["HOME", "關於曼陀號", "計畫介紹"]} />
+      <MarqueeTitle zhTitle="計畫介紹" enTitle="Overview" />
+    </div>
+  );
 }

--- a/nextjs-app/app/about/philosophy/page.tsx
+++ b/nextjs-app/app/about/philosophy/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from "next";
+import Breadcrumb from "@/components/common/Breadcrumb";
+import MarqueeTitle from "@/components/common/MarqueeTitle";
 
 export const metadata: Metadata = {
   title: "曼陀號理念",
 };
 
 export default async function PhilosophyPage() {
-  return <div>曼陀號理念</div>;
+  return (
+    <div>
+      <Breadcrumb items={["HOME", "關於曼陀號", "曼陀號理念"]} />
+      <MarqueeTitle zhTitle="曼陀號理念" enTitle="Philosophy" />
+    </div>
+  );
 }

--- a/nextjs-app/app/about/team/page.tsx
+++ b/nextjs-app/app/about/team/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from "next";
+import Breadcrumb from "@/components/common/Breadcrumb";
+import MarqueeTitle from "@/components/common/MarqueeTitle";
 
 export const metadata: Metadata = {
   title: "團隊成員",
 };
 
 export default async function TeamPage() {
-  return <div>team page</div>;
+  return (
+    <div>
+      <Breadcrumb items={["HOME", "關於曼陀號", "團隊成員"]} />
+      <MarqueeTitle zhTitle="團隊成員" enTitle="Team" />
+    </div>
+  );
 }

--- a/nextjs-app/app/faq/page.tsx
+++ b/nextjs-app/app/faq/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
+import MarqueeTitle from "@/components/common/MarqueeTitle";
 
 export const metadata: Metadata = {
   title: "常見問題",
@@ -9,6 +10,7 @@ export default async function FAQPage() {
   return (
     <div>
       <Breadcrumb items={["HOME", "常見問題"]} />
+      <MarqueeTitle zhTitle="常見問題" enTitle="FAQ" />
     </div>
   );
 }

--- a/nextjs-app/app/program-rules/page.tsx
+++ b/nextjs-app/app/program-rules/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from "next";
+import Breadcrumb from "@/components/common/Breadcrumb";
+import MarqueeTitle from "@/components/common/MarqueeTitle";
 
 export const metadata: Metadata = {
   title: "活動辦法",
 };
 
 export default async function ProgramRulesPage() {
-  return <div>活動辦法</div>;
+  return (
+    <div>
+      <Breadcrumb items={["HOME", "活動辦法"]} />
+      <MarqueeTitle zhTitle="活動辦法" enTitle="The MentorShip Program" />
+    </div>
+  );
 }

--- a/nextjs-app/components/common/MarqueeTitle.tsx
+++ b/nextjs-app/components/common/MarqueeTitle.tsx
@@ -6,9 +6,26 @@ interface MarqueeTitleProps {
   enTitle: string;
 }
 
-const repeatedArray: number[] = Array.from({ length: 8 }, (_, index) => index);
+/**
+ * Determines the number of times to repeat the marquee text based on text length
+ * @param text The text to be displayed
+ * @returns {number} Number of repetitions
+ * - text length >= 20 chars: repeat 4 times
+ * - text length >= 10 chars: repeat 8 times
+ * - text length < 10 chars:  repeat 15 times
+ */
+const getRepeatCount = (text: string) => {
+  if (text.length >= 20) return 4;
+  if (text.length >= 10) return 8;
+  return 15;
+};
 
 const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
+  const repeatedArray = Array.from(
+    { length: getRepeatCount(enTitle) },
+    (_, index) => index
+  );
+
   return (
     <section className="relative overflow-hidden py-[64px] md:py-[112px]">
       <div className="absolute inset-0 w-full overflow-hidden md:top-5">
@@ -23,7 +40,7 @@ const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
               </span>
             ))}
           </div>
-          <div className="flex shrink-0 items-center animate-marquee-second-layer [animation-delay:-50s]">
+          <div className="flex shrink-0 items-center animate-marquee-second-layer [animation-delay:-90s]">
             {repeatedArray.map((_, index) => (
               <span
                 key={`second-${index.toString()}`}

--- a/nextjs-app/components/common/MarqueeTitle.tsx
+++ b/nextjs-app/components/common/MarqueeTitle.tsx
@@ -11,11 +11,10 @@ interface MarqueeTitleProps {
  * @param text The text to be displayed
  * @returns {number} Number of repetitions
  * - text length >= 20 chars: repeat 4 times
- * - text length >= 10 chars: repeat 8 times
- * - text length < 10 chars:  repeat 15 times
+ * - text length >= 8 chars: repeat 8 times
+ * - text length < 8 chars:  repeat 15 times
  */
 const getRepeatCount = (text: string) => {
-  console.log(text.length);
   if (text.length >= 20) return 4;
   if (text.length >= 8) return 8;
   return 15;

--- a/nextjs-app/components/common/MarqueeTitle.tsx
+++ b/nextjs-app/components/common/MarqueeTitle.tsx
@@ -1,0 +1,61 @@
+import { FC } from "react";
+import Image from "next/image";
+
+interface MarqueeTitleProps {
+  zhTitle: string;
+  enTitle: string;
+}
+
+const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
+  const repeatedArray: number[] = Array.from(
+    { length: 20 },
+    (_, index) => index
+  );
+
+  return (
+    <section className="relative overflow-hidden py-[64px] md:py-[112px]">
+      <div className="absolute inset-0 w-full overflow-hidden top-2 md:top-4">
+        <div className="flex">
+          <div className="flex shrink-0 items-center animate-marquee-1">
+            {repeatedArray.map((_, index) => (
+              <span
+                key={`first-${index.toString()}`}
+                className="inline-block mx-4 text-[64px] md:text-[96px] font-eb-garamond text-yellow-1"
+              >
+                {enTitle}
+              </span>
+            ))}
+          </div>
+          <div className="flex shrink-0 items-center animate-marquee-2 [animation-delay:-40s]">
+            {repeatedArray.map((_, index) => (
+              <span
+                key={`second-${index.toString()}`}
+                className="inline-block mx-4 text-[64px] md:text-[96px] font-eb-garamond text-yellow-1"
+              >
+                {enTitle}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="relative z-10 flex flex-col items-center justify-center text-center">
+        <h2 className="text-h5 md:text-h4 text-yellow-6 mb-2 md:mb-3">
+          {zhTitle}
+        </h2>
+        <h3 className="text-h1-title font-eb-garamond mb-8 text-blue-8">
+          {enTitle}
+        </h3>
+        <Image
+          src="/images/title-symbol-line.png"
+          alt="title-symbol-line"
+          width={57}
+          height={5}
+          className="mx-auto"
+        />
+      </div>
+    </section>
+  );
+};
+
+export default MarqueeTitle;

--- a/nextjs-app/components/common/MarqueeTitle.tsx
+++ b/nextjs-app/components/common/MarqueeTitle.tsx
@@ -15,8 +15,9 @@ interface MarqueeTitleProps {
  * - text length < 10 chars:  repeat 15 times
  */
 const getRepeatCount = (text: string) => {
+  console.log(text.length);
   if (text.length >= 20) return 4;
-  if (text.length >= 10) return 8;
+  if (text.length >= 8) return 8;
   return 15;
 };
 

--- a/nextjs-app/components/common/MarqueeTitle.tsx
+++ b/nextjs-app/components/common/MarqueeTitle.tsx
@@ -6,17 +6,14 @@ interface MarqueeTitleProps {
   enTitle: string;
 }
 
-const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
-  const repeatedArray: number[] = Array.from(
-    { length: 20 },
-    (_, index) => index
-  );
+const repeatedArray: number[] = Array.from({ length: 8 }, (_, index) => index);
 
+const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
   return (
     <section className="relative overflow-hidden py-[64px] md:py-[112px]">
-      <div className="absolute inset-0 w-full overflow-hidden top-2 md:top-4">
+      <div className="absolute inset-0 w-full overflow-hidden md:top-5">
         <div className="flex">
-          <div className="flex shrink-0 items-center animate-marquee-1">
+          <div className="flex shrink-0 items-center animate-marquee-first-layer">
             {repeatedArray.map((_, index) => (
               <span
                 key={`first-${index.toString()}`}
@@ -26,7 +23,7 @@ const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
               </span>
             ))}
           </div>
-          <div className="flex shrink-0 items-center animate-marquee-2 [animation-delay:-40s]">
+          <div className="flex shrink-0 items-center animate-marquee-second-layer [animation-delay:-50s]">
             {repeatedArray.map((_, index) => (
               <span
                 key={`second-${index.toString()}`}
@@ -38,7 +35,6 @@ const MarqueeTitle: FC<MarqueeTitleProps> = ({ zhTitle, enTitle }) => {
           </div>
         </div>
       </div>
-
       <div className="relative z-10 flex flex-col items-center justify-center text-center">
         <h2 className="text-h5 md:text-h4 text-yellow-6 mb-2 md:mb-3">
           {zhTitle}

--- a/nextjs-app/tailwind.config.ts
+++ b/nextjs-app/tailwind.config.ts
@@ -51,8 +51,8 @@ export default {
         ...typographyFromToken,
       },
       animation: {
-        "marquee-first-layer": "marquee1 100s linear infinite",
-        "marquee-second-layer": "marquee2 100s linear infinite",
+        "marquee-first-layer": "marquee1 180s linear infinite",
+        "marquee-second-layer": "marquee2 180s linear infinite",
       },
       keyframes: {
         marquee1: {

--- a/nextjs-app/tailwind.config.ts
+++ b/nextjs-app/tailwind.config.ts
@@ -50,6 +50,20 @@ export default {
         ...fontSize,
         ...typographyFromToken,
       },
+      animation: {
+        "marquee-1": "marquee1 80s linear infinite",
+        "marquee-2": "marquee2 80s linear infinite",
+      },
+      keyframes: {
+        marquee1: {
+          "0%": { transform: "translateX(0%)" },
+          "100%": { transform: "translateX(-100%)" },
+        },
+        marquee2: {
+          "0%": { transform: "translateX(100%)" },
+          "100%": { transform: "translateX(0%)" },
+        },
+      },
     },
   },
   future: {

--- a/nextjs-app/tailwind.config.ts
+++ b/nextjs-app/tailwind.config.ts
@@ -51,17 +51,17 @@ export default {
         ...typographyFromToken,
       },
       animation: {
-        "marquee-1": "marquee1 80s linear infinite",
-        "marquee-2": "marquee2 80s linear infinite",
+        "marquee-first-layer": "marquee1 100s linear infinite",
+        "marquee-second-layer": "marquee2 100s linear infinite",
       },
       keyframes: {
         marquee1: {
-          "0%": { transform: "translateX(0%)" },
+          "0%": { transform: "translateX(100%)" },
           "100%": { transform: "translateX(-100%)" },
         },
         marquee2: {
-          "0%": { transform: "translateX(100%)" },
-          "100%": { transform: "translateX(0%)" },
+          "0%": { transform: "translateX(0%)" },
+          "100%": { transform: "translateX(-200%)" },
         },
       },
     },


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #41 
- `MarqueeTitle` component (for the animation, I refer to [this article](https://ithelp.ithome.com.tw/m/articles/10268962))
- based on the length of the text, we need to change the repeat time so that the speed for the animation could be similar on different pages
- add breadcrumb and marquee section to each pages
- Reference website provided by designer (https://school.kawa-sui.com/admission/)
- Check the animation effect with designer and she thinks it is good


https://github.com/user-attachments/assets/d99eb41a-f48c-4b13-aaa1-6f8b1c9dca20



## Changes made:

-

## Test Scope / Change impact:

-
