### PR TITLE
feat: InfoCard common component & integrate cva and tailwind-merge

### DIFF
--- a/nextjs-app/components/common/Button.tsx
+++ b/nextjs-app/components/common/Button.tsx
@@ -1,8 +1,8 @@
 import { FC, PropsWithChildren } from "react";
 
-type ButtonVariant = "filled" | "outline";
+export type ButtonVariant = "filled" | "outline";
 
-type ButtonColor = "blue" | "golden";
+export type ButtonColor = "blue" | "golden";
 
 interface ICallToActionLinkProps {
   className?: string;

--- a/nextjs-app/components/common/InfoCard.tsx
+++ b/nextjs-app/components/common/InfoCard.tsx
@@ -1,0 +1,104 @@
+import Image from "next/image";
+import Link from "next/link";
+import { twMerge } from "tailwind-merge";
+import { cva, type VariantProps } from "class-variance-authority";
+import Button, { ButtonVariant, ButtonColor } from "@/components/common/Button";
+
+const infoCardVariants = cva(
+  "bg-white rounded-3 relative h-full flex flex-col",
+  {
+    variants: {
+      background: {
+        white: "bg-white",
+        navy: "bg-blue-1",
+      },
+      border: {
+        none: "border-none",
+        bordered: "border border-solid border-[1px] border-yellow-6",
+      },
+    },
+    defaultVariants: {
+      background: "white",
+      border: "none",
+    },
+  }
+);
+
+interface IInfoCardProps extends VariantProps<typeof infoCardVariants> {
+  title: string;
+  description: string;
+  imageUrl: string;
+  buttonText?: string;
+  buttonClassName?: string;
+  buttonVariant?: ButtonVariant;
+  buttonColor?: ButtonColor;
+  serial?: string;
+  externalLink?: string;
+}
+
+const InfoCard = ({
+  background,
+  border,
+  title,
+  description,
+  imageUrl,
+  buttonText,
+  serial,
+  externalLink,
+  buttonClassName,
+  buttonVariant = "filled",
+  buttonColor = "blue",
+}: IInfoCardProps) => {
+  return (
+    <div className={infoCardVariants({ background, border })}>
+      {serial && (
+        <div className="absolute text-h5 -top-5 -left-[13px] bg-yellow-6 text-white w-[52px] h-[52px] flex items-center justify-center rounded-2">
+          {serial}
+        </div>
+      )}
+      <div className="flex flex-col items-center h-full text-center py-8 px-7">
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt={title}
+            width={80}
+            height={80}
+            className="w-[80px] h-[80px] object-cover mb-6"
+          />
+        )}
+        <h3 className="text-h5 text-yellow-6 mb-3 whitespace-pre-line">
+          {title}
+        </h3>
+        <p className="text-body-lg text-neutral-10">{description}</p>
+        {buttonText &&
+          (externalLink ? (
+            <Link href={externalLink} target="_blank" className="w-full">
+              <Button
+                className={twMerge(
+                  "mt-6 w-full md:w-auto justify-center",
+                  buttonClassName
+                )}
+                variant={buttonVariant}
+                color={buttonColor}
+              >
+                {buttonText}
+              </Button>
+            </Link>
+          ) : (
+            <Button
+              className={twMerge(
+                "mt-6 w-full md:w-auto justify-center",
+                buttonClassName
+              )}
+              variant={buttonVariant}
+              color={buttonColor}
+            >
+              {buttonText}
+            </Button>
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default InfoCard;

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^18.3.1",
     "@vercel/speed-insights": "^1.1.0",
     "autoprefixer": "^10.4.20",
+    "class-variance-authority": "^0.7.1",
     "date-fns": "^3.6.0",
     "next": "^15.0.3",
     "next-sanity": "^9.8.11",
@@ -27,6 +28,7 @@
     "sanity": "^3.63.0",
     "sonner": "^1.7.0",
     "styled-components": "^6.1.13",
+    "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.14",
     "typescript": "5.6.3"
   },

--- a/nextjs-app/pnpm-lock.yaml
+++ b/nextjs-app/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -59,6 +62,9 @@ importers:
       styled-components:
         specifier: ^6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.0
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.15
@@ -2125,6 +2131,9 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
@@ -2158,6 +2167,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -4673,6 +4686,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
   tailwindcss-motion@1.0.0:
     resolution: {integrity: sha512-Bc8XJxiSGjup0NHsph4OBGXXFfmbInFUhvVVluKPScQD1R2kDQTZIODqumsI/lONryeTpDdKzwuuw1a99Z38bQ==}
@@ -7437,6 +7453,10 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   classnames@2.5.1: {}
 
   cli-cursor@3.1.0:
@@ -7469,6 +7489,8 @@ snapshots:
       shallow-clone: 3.0.1
 
   clone@1.0.4: {}
+
+  clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -10382,6 +10404,8 @@ snapshots:
       picocolors: 1.1.1
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@2.6.0: {}
 
   tailwindcss-motion@1.0.0(tailwindcss@3.4.15):
     dependencies:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "sonner": "^1.7.0",
     "styled-components": "^6.1.13",
     "tailwindcss": "^3.4.14",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "class-variance-authority": "^0.7.1",
+    "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",


### PR DESCRIPTION
## Why need this change? / Root cause:

- install `cva` and `tailwind-merge` library
- create `InfoCard` common component, we need to support the variants like below

<img width="125" alt="截圖 2025-01-16 凌晨12 04 57" src="https://github.com/user-attachments/assets/568789a0-7d0e-41b0-8a06-3791a57fbb32" />
<img width="101" alt="截圖 2025-01-16 凌晨12 05 08" src="https://github.com/user-attachments/assets/a87c9fb2-7f00-4e50-ab96-a5e75946b691" />
<img width="153" alt="截圖 2025-01-16 凌晨12 05 15" src="https://github.com/user-attachments/assets/06a54273-4037-4a44-910f-3cfc5072a701" />
<img width="98" alt="截圖 2025-01-16 凌晨12 05 25" src="https://github.com/user-attachments/assets/92325870-b661-47b0-87c2-c9d8a1c2be52" />
<img width="105" alt="截圖 2025-01-16 凌晨12 05 30" src="https://github.com/user-attachments/assets/7fabf449-cc30-4b9e-8a01-dc5e0d184a71" />

Below is the sample, we can use props to control the variant of info card
<img width="1473" alt="截圖 2025-01-16 凌晨12 01 13" src="https://github.com/user-attachments/assets/c65a30b7-ab37-4d61-8ce1-e35d60b8c3f6" />


## Changes made:

-

## Test Scope / Change impact:

-
