### PR TITLE
feat: section title component in program rules page

### DIFF
--- a/nextjs-app/app/program-rules/page.tsx
+++ b/nextjs-app/app/program-rules/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
+import Benefits from "@/components/pages/program-rules/Benefits";
+import JoinUs from "@/components/pages/program-rules/JoinUs";
 
 export const metadata: Metadata = {
   title: "活動辦法",
@@ -11,6 +13,8 @@ export default async function ProgramRulesPage() {
     <div>
       <Breadcrumb items={["HOME", "活動辦法"]} />
       <MarqueeTitle zhTitle="活動辦法" enTitle="The MentorShip Program" />
+      <Benefits />
+      <JoinUs />
     </div>
   );
 }

--- a/nextjs-app/components/pages/main/Partners.tsx
+++ b/nextjs-app/components/pages/main/Partners.tsx
@@ -46,42 +46,44 @@ const programPartners = [
 
 const Partners = () => {
   return (
-    <section className="py-[72px] bg-neutral-1 md:py-[120px]">
-      <div className="mx-auto text-center">
-        <h2 className="text-h5 md:text-h4 text-yellow-6 mb-2">合作夥伴</h2>
-        <h3 className="text-h3-title md:text-h1-title font-eb-garamond mb-6 md:mb-8 text-blue-8">
-          Our Partners
-        </h3>
-        <Image
-          src="/images/title-symbol-line.png"
-          alt="title-symbol-line"
-          width={57}
-          height={5}
-          className="mx-auto mb-11"
-        />
-        <div className="w-full px-5 md:px-10 xl:px-[142px]">
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-7">
-            {programPartners.map((partner, idx) => (
-              <a
-                key={idx}
-                href={partner.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-white rounded-3"
-              >
-                <Image
-                  src={partner.imageSrc}
-                  alt={`${partner.name} logo`}
-                  width={324}
-                  height={108}
-                  className="object-contain h-[108px] w-full"
-                />
-              </a>
-            ))}
+    <div className="w-full bg-neutral-1">
+      <section className="container py-[72px] bg-neutral-1 md:py-[120px]">
+        <div className="mx-auto text-center">
+          <h2 className="text-h5 md:text-h4 text-yellow-6 mb-2">合作夥伴</h2>
+          <h3 className="text-h3-title md:text-h1-title font-eb-garamond mb-6 md:mb-8 text-blue-8">
+            Our Partners
+          </h3>
+          <Image
+            src="/images/title-symbol-line.png"
+            alt="title-symbol-line"
+            width={57}
+            height={5}
+            className="mx-auto mb-11"
+          />
+          <div className="w-full px-5 md:px-10 xl:px-[142px]">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-7">
+              {programPartners.map((partner, idx) => (
+                <a
+                  key={idx}
+                  href={partner.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-white rounded-3"
+                >
+                  <Image
+                    src={partner.imageSrc}
+                    alt={`${partner.name} logo`}
+                    width={324}
+                    height={108}
+                    className="object-contain h-[108px] w-full"
+                  />
+                </a>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
   );
 };
 

--- a/nextjs-app/components/pages/main/StayUpdated.tsx
+++ b/nextjs-app/components/pages/main/StayUpdated.tsx
@@ -49,7 +49,7 @@ const socialLinks = [
 
 const StayUpdated = () => {
   return (
-    <section className="pt-[72px] pb-[90px] md:py-[120px]">
+    <section className="container pt-[72px] pb-[90px] md:py-[120px]">
       <div className="mx-auto text-center">
         <h2 className="text-h5 md:text-h4 text-yellow-6 mb-2">
           關注第一手消息

--- a/nextjs-app/components/pages/program-rules/Benefits.tsx
+++ b/nextjs-app/components/pages/program-rules/Benefits.tsx
@@ -1,0 +1,18 @@
+import SectionTitle from "@/components/pages/program-rules/SectionTitle";
+
+const Benefits = () => {
+  return (
+    <section className="bg-blue-8 px-5 py-[72px] md:px-10 md:py-[120px]">
+      <SectionTitle
+        title="參加曼陀號，你將會收穫"
+        description={
+          "我們提供豐富的活動、資源與交流機會，不怕活動太多，只怕你參與不夠"
+        }
+        serial="01"
+        variant="dark"
+      />
+    </section>
+  );
+};
+
+export default Benefits;

--- a/nextjs-app/components/pages/program-rules/JoinUs.tsx
+++ b/nextjs-app/components/pages/program-rules/JoinUs.tsx
@@ -1,0 +1,18 @@
+import SectionTitle from "@/components/pages/program-rules/SectionTitle";
+
+const JoinUs = () => {
+  return (
+    <section className="bg-white px-5 py-[72px] md:px-10 md:py-[120px]">
+      <SectionTitle
+        title="邀請這樣的你加入"
+        description={
+          "如果你符合以下特質，我們熱切邀請你加入曼陀號，因為你一定會在這裡有所成長！"
+        }
+        serial="02"
+        variant="light"
+      />
+    </section>
+  );
+};
+
+export default JoinUs;

--- a/nextjs-app/components/pages/program-rules/SectionTitle.tsx
+++ b/nextjs-app/components/pages/program-rules/SectionTitle.tsx
@@ -1,0 +1,86 @@
+import type { FC } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { twMerge } from "tailwind-merge";
+
+const sectionTitleVariants = {
+  container: cva("text-center flex flex-col", {
+    variants: {
+      variant: {
+        light: "",
+        dark: "",
+      },
+    },
+    defaultVariants: {
+      variant: "light",
+    },
+  }),
+  serial: cva("text-subtitle-md mb-1", {
+    variants: {
+      variant: {
+        light: "text-yellow-6",
+        dark: "text-white",
+      },
+    },
+  }),
+  title: cva("text-h3 md:text-h2 mb-6", {
+    variants: {
+      variant: {
+        light: "text-blue-8",
+        dark: "text-white",
+      },
+    },
+  }),
+  description: cva("text-body-md whitespace-pre-line", {
+    variants: {
+      variant: {
+        light: "text-neutral-10",
+        dark: "text-white",
+      },
+    },
+  }),
+  note: cva("text-body-sm mt-3 whitespace-pre-line", {
+    variants: {
+      variant: {
+        light: "text-neutral-10",
+        dark: "text-white",
+      },
+    },
+  }),
+};
+
+interface ISectionTitleProps
+  extends VariantProps<typeof sectionTitleVariants.container> {
+  className?: string;
+  serial: string;
+  title: string;
+  description?: string;
+  note?: string;
+}
+
+const SectionTitle: FC<ISectionTitleProps> = ({
+  className,
+  title,
+  serial,
+  description,
+  note,
+  variant = "light",
+}) => {
+  return (
+    <div className={twMerge(className)}>
+      <div className={sectionTitleVariants.container({ variant })}>
+        <p className={sectionTitleVariants.serial({ variant })}>{serial}</p>
+        <h2 className={sectionTitleVariants.title({ variant })}>{title}</h2>
+        {description && (
+          <p className={sectionTitleVariants.description({ variant })}>
+            {description}
+          </p>
+        )}
+        {note && (
+          <p className={sectionTitleVariants.note({ variant })}>{note}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SectionTitle;


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #63 
- add `SectionTitle` component in program rules page
- add `container` class to some section in previous PR

<img width="1490" alt="截圖 2025-01-16 下午3 38 25" src="https://github.com/user-attachments/assets/b79f0957-579b-41af-9497-7389042fa646" />


## Changes made:

-

## Test Scope / Change impact:

-
