### PR TITLE
feat: Update design token

### DIFF
--- a/nextjs-app/design-system/data/token.json
+++ b/nextjs-app/design-system/data/token.json
@@ -35,6 +35,14 @@
     "9": {
       "value": "32px",
       "type": "fontSizes"
+    },
+    "10": {
+      "value": "40px",
+      "type": "fontSizes"
+    },
+    "11": {
+      "value": "48px",
+      "type": "fontSizes"
     }
   },
   "lineHeights": {
@@ -80,6 +88,10 @@
     },
     "11": {
       "value": "48px",
+      "type": "lineHeights"
+    },
+    "12": {
+      "value": "56px",
       "type": "lineHeights"
     }
   },
@@ -127,11 +139,11 @@
       "type": "borderRadius"
     },
     "circle": {
-      "value": "50%",
+      "value": "999px",
       "type": "borderRadius"
     },
     "pill": {
-      "value": "9999px",
+      "value": "999px",
       "type": "borderRadius"
     }
   },
@@ -264,7 +276,7 @@
       "value": {
         "lineHeight": "52px",
         "fontSize": "40px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -272,7 +284,7 @@
       "value": {
         "lineHeight": "44px",
         "fontSize": "28px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -280,7 +292,7 @@
       "value": {
         "lineHeight": "40px",
         "fontSize": "26px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -288,7 +300,7 @@
       "value": {
         "lineHeight": "32px",
         "fontSize": "24px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -296,7 +308,7 @@
       "value": {
         "lineHeight": "28px",
         "fontSize": "22px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -304,7 +316,7 @@
       "value": {
         "lineHeight": "24px",
         "fontSize": "18px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -312,7 +324,7 @@
       "value": {
         "lineHeight": "24px",
         "fontSize": "16px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -320,7 +332,7 @@
       "value": {
         "lineHeight": "20px",
         "fontSize": "14px",
-        "fontWeight": 700
+        "fontWeight": 600
       },
       "type": "typography"
     },
@@ -467,7 +479,7 @@
       "type": "color"
     },
     "10": {
-      "value": "#684D22",
+      "value": "#5E4113",
       "type": "color"
     }
   },


### PR DESCRIPTION
## Why need this change? / Root cause:

Based on Figma, update design token

<img width="600" alt="image" src="https://github.com/user-attachments/assets/1cbfc1ff-a124-4781-a80f-1d5303098a81" />


## Changes made:

- Update design token
  - Add new `font-size`
  - Adjust `typography` font-weight
  - Adjust `radius` value
  - Adjust color `yellow` value

## Test Scope / Change impact:

-
