### PR TITLE
refactor: integrte import order linter and auto fix existing files

### DIFF
--- a/nextjs-app/.eslintrc
+++ b/nextjs-app/.eslintrc
@@ -8,6 +8,7 @@
     "next/typescript",
     "prettier",
   ],
+  "plugins": ["import"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "projectService": true,
@@ -15,6 +16,28 @@
   "rules": {
     "require-await": "off",
     "@typescript-eslint/require-await": "off",
-    "@typescript-eslint/no-redundant-type-constituents": "off"
+    "@typescript-eslint/no-redundant-type-constituents": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          ["parent", "sibling", "index"],
+          "object",
+          "type"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "@/**",
+            "group": "internal",
+            "position": "after"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["builtin"],
+        "distinctGroup": true,
+      }
+    ]
   },
 }

--- a/nextjs-app/app/about/overview/page.tsx
+++ b/nextjs-app/app/about/overview/page.tsx
@@ -1,6 +1,6 @@
-import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "計畫介紹",

--- a/nextjs-app/app/about/philosophy/page.tsx
+++ b/nextjs-app/app/about/philosophy/page.tsx
@@ -1,6 +1,6 @@
-import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "曼陀號理念",

--- a/nextjs-app/app/about/team/page.tsx
+++ b/nextjs-app/app/about/team/page.tsx
@@ -1,6 +1,6 @@
-import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "團隊成員",

--- a/nextjs-app/app/faq/page.tsx
+++ b/nextjs-app/app/faq/page.tsx
@@ -1,7 +1,7 @@
-import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
 import ContentWithFilter from "@/components/pages/faq/ContentWithFilter";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "常見問題",

--- a/nextjs-app/app/layout.tsx
+++ b/nextjs-app/app/layout.tsx
@@ -1,9 +1,9 @@
 import "./globals.css";
-import type { Metadata } from "next";
 import { EB_Garamond } from "next/font/google";
 import Footer from "@/components/common/Footer";
 import Header from "@/components/common/Header";
 import { METADATA } from "@/constants/metadata";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: {

--- a/nextjs-app/app/page.tsx
+++ b/nextjs-app/app/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import { METADATA } from "@/constants/metadata";
 import WhatWeDo from "@/components/pages/main/WhatWeDo";
 import StayUpdated from "@/components/pages/main/StayUpdated";
@@ -6,6 +5,7 @@ import Partners from "@/components/pages/main/Partners";
 import WhatWeBring from "@/components/pages/main/WhatWeBring";
 import WhoWeAre from "@/components/pages/main/WhoWeAre";
 import Testimonial from "@/components/pages/main/Testimonial";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: `首頁 - ${METADATA.projectName}`,

--- a/nextjs-app/app/program-rules/page.tsx
+++ b/nextjs-app/app/program-rules/page.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from "next";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
 import Benefits from "@/components/pages/program-rules/Benefits";
 import JoinUs from "@/components/pages/program-rules/JoinUs";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "活動辦法",

--- a/nextjs-app/components/common/Header/Header.tsx
+++ b/nextjs-app/components/common/Header/Header.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
 
-import HamburgerButton from "./HamburgerButton";
-
 import Routes from "@/constants/routes";
 import {
   MENTORSHIP_FACEBOOK_URL,
@@ -14,6 +12,7 @@ import { default as FacebookIcon } from "@/public/images/facebook-logo.svg";
 import { default as LinkedInIcon } from "@/public/images/linkedin-logo.svg";
 import { default as InstagramIcon } from "@/public/images/instagram-logo.svg";
 import { default as CompassIcon } from "@/public/images/compass.svg";
+import HamburgerButton from "./HamburgerButton";
 
 const desktopNavigationMenu = [
   {

--- a/nextjs-app/components/common/ReviewCard.tsx
+++ b/nextjs-app/components/common/ReviewCard.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import { default as ReviewStar } from "@/public/images/review-star.svg";
 import { FC } from "react";
 import { IReview } from "@/types/review";
+import { default as ReviewStar } from "@/public/images/review-star.svg";
 
 const ReviewCard: FC<IReview> = ({ imageSrc, name, team, role, review }) => (
   <div className="mx-[6px] md:mx-4 p-6 flex flex-col items-start space-y-3 border-2 border-neutral-2 rounded-3">

--- a/nextjs-app/components/pages/faq/ContentWithFilter.tsx
+++ b/nextjs-app/components/pages/faq/ContentWithFilter.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import TagFilter from "@/components/common/TagFilter/TagFilter";
 import { FAQ_FILTER_OPTIONS } from "@/constants/filter-options";
-import { useState } from "react";
 
 const ContentWithFilter = () => {
   const [selectedFilter, setSelectedFilter] = useState("all");

--- a/nextjs-app/components/pages/main/SectionTitle.tsx
+++ b/nextjs-app/components/pages/main/SectionTitle.tsx
@@ -1,5 +1,5 @@
-import type { FC } from "react";
 import Image from "next/image";
+import type { FC } from "react";
 
 interface ISectionTitleProps {
   className?: string;

--- a/nextjs-app/components/pages/main/WhatWeBring.tsx
+++ b/nextjs-app/components/pages/main/WhatWeBring.tsx
@@ -1,7 +1,7 @@
-import Button from "@/components/common/Button";
 import Image from "next/image";
 import Link from "next/link";
 import { FC } from "react";
+import Button from "@/components/common/Button";
 
 interface IGoalCardProps {
   imageSrc: string;

--- a/nextjs-app/components/pages/main/WhatWeDo.tsx
+++ b/nextjs-app/components/pages/main/WhatWeDo.tsx
@@ -1,6 +1,6 @@
-import Button from "@/components/common/Button";
 import Image from "next/image";
 import Link from "next/link";
+import Button from "@/components/common/Button";
 
 const WhatWeDo = () => {
   return (

--- a/nextjs-app/components/pages/main/WhoWeAre.tsx
+++ b/nextjs-app/components/pages/main/WhoWeAre.tsx
@@ -1,5 +1,5 @@
-import type { FC } from "react";
 import Image, { StaticImageData } from "next/image";
+import Link from "next/link";
 import { Team, Role } from "@/types";
 import { roleDisplayTextMap } from "@/constants/roleDisplayTextMap";
 
@@ -12,9 +12,9 @@ import AvatarForKyle from "@/public/images/member-avatar/Kyle.jpg";
 import AvatarForMila from "@/public/images/member-avatar/Mila.jpg";
 import AvatarForPatty from "@/public/images/member-avatar/Patty.jpg";
 
-import SectionTitle from "./SectionTitle";
 import Button from "@/components/common/Button";
-import Link from "next/link";
+import SectionTitle from "./SectionTitle";
+import type { FC } from "react";
 
 interface ITeamMember {
   avatar: StaticImageData;

--- a/nextjs-app/components/pages/program-rules/SectionTitle.tsx
+++ b/nextjs-app/components/pages/program-rules/SectionTitle.tsx
@@ -1,6 +1,6 @@
-import type { FC } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { twMerge } from "tailwind-merge";
+import type { FC } from "react";
 
 const sectionTitleVariants = {
   container: cva("text-center flex flex-col", {

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:fix": "next lint --fix",
     "typegen": "sanity typegen generate"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.0.3",
     "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-import": "^2.31.0",
     "husky": "9.1.6",
     "lint-staged": "15.2.10",
     "prettier": "3.4.2",

--- a/nextjs-app/pnpm-lock.yaml
+++ b/nextjs-app/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       eslint-config-prettier:
         specifier: 9.1.0
         version: 9.1.0(eslint@8.57.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       husky:
         specifier: 9.1.6
         version: 9.1.6

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "husky": "9.1.6",
     "lint-staged": "15.2.10",
     "prettier": "3.4.2",
-    "tailwindcss-motion": "^1.0.0"
+    "tailwindcss-motion": "^1.0.0",
+    "eslint-plugin-import": "^2.31.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #82 

## Changes made:

- add `pnpm run lint:fix` script
- integrate `eslint-plugin-import` for standardizing the import order rule in codebase
- the order is like the following
  - `builtin`
  - `external` (like `react`)
  - `internal` (alias `@` should have higher priority, and for relative path, the order is `parent`, `sibling`, `index`)
  - `type`

## Test Scope / Change impact:

-
