### PR TITLE
feat: group intro section in overview page & PageNavigationCard common component

### DIFF
--- a/nextjs-app/app/about/overview/page.tsx
+++ b/nextjs-app/app/about/overview/page.tsx
@@ -3,6 +3,7 @@ import MarqueeTitle from "@/components/common/MarqueeTitle";
 import ProgramIntroduction from "@/components/pages/about/overview/ProgramIntroduction";
 import MonthlyMeetingRoles from "@/components/pages/about/overview/MonthlyMeetingRoles";
 import RecruitmentTargets from "@/components/pages/about/overview/RecruitmentTargets";
+import GroupsIntro from "@/components/pages/about/overview/GroupsIntro";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -17,6 +18,7 @@ export default async function OverviewPage() {
       <ProgramIntroduction />
       <MonthlyMeetingRoles />
       <RecruitmentTargets />
+      <GroupsIntro />
     </div>
   );
 }

--- a/nextjs-app/components/common/PageNavigationCard.tsx
+++ b/nextjs-app/components/common/PageNavigationCard.tsx
@@ -1,0 +1,53 @@
+import { FC } from "react";
+import { twMerge } from "tailwind-merge";
+import Image from "next/image";
+import Link from "next/link";
+import Button from "@/components/common/Button/Button";
+
+interface IPageNavigationCardProps {
+  imageSrc: string;
+  enTitle: string;
+  zhTitle: string;
+  buttonText: string;
+  buttonLink: string;
+  className?: string;
+}
+
+const PageNavigationCard: FC<IPageNavigationCardProps> = ({
+  imageSrc,
+  enTitle,
+  zhTitle,
+  buttonText,
+  buttonLink,
+  className,
+}) => {
+  return (
+    <div
+      className={twMerge(
+        "px-7 py-8 md:py-[44px] bg-white rounded-3 flex items-center",
+        className
+      )}
+    >
+      <Image
+        src={imageSrc}
+        alt={enTitle}
+        width={80}
+        height={80}
+        className="w-[80px] h-[80px] md:w-[64px] md:h-[64px]"
+      />
+      <div className="ml-7 md:ml-5 flex-1 xl:flex xl:justify-between xl:items-center">
+        <div>
+          <h3 className="text-h3-title text-yellow-6 font-eb-garamond">
+            {enTitle}
+          </h3>
+          <p className="text-subtitle-md">{zhTitle}</p>
+        </div>
+        <Link href={buttonLink}>
+          <Button className="mt-4 xl:mt-0 px-7">{buttonText}</Button>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default PageNavigationCard;

--- a/nextjs-app/components/common/PageNavigationCard.tsx
+++ b/nextjs-app/components/common/PageNavigationCard.tsx
@@ -35,7 +35,7 @@ const PageNavigationCard: FC<IPageNavigationCardProps> = ({
         height={80}
         className="w-[80px] h-[80px] md:w-[64px] md:h-[64px]"
       />
-      <div className="ml-7 md:ml-5 flex-1 xl:flex xl:justify-between xl:items-center">
+      <div className="ml-7 md:ml-5 flex-1 md:flex md:justify-between md:items-center flex-wrap gap-4">
         <div>
           <h3 className="text-h3-title text-yellow-6 font-eb-garamond">
             {enTitle}
@@ -43,7 +43,7 @@ const PageNavigationCard: FC<IPageNavigationCardProps> = ({
           <p className="text-subtitle-md">{zhTitle}</p>
         </div>
         <Link href={buttonLink}>
-          <Button className="mt-4 xl:mt-0 px-7">{buttonText}</Button>
+          <Button className="mt-4 md:mt-0 px-7">{buttonText}</Button>
         </Link>
       </div>
     </div>

--- a/nextjs-app/components/pages/about/overview/GroupsIntro.tsx
+++ b/nextjs-app/components/pages/about/overview/GroupsIntro.tsx
@@ -6,7 +6,7 @@ import Routes from "@/constants/routes";
 const GroupsIntro = () => {
   return (
     <div className="w-full bg-neutral-1">
-      <section className="container px-3 py-[72px] md:px-10 md:py-[120px]">
+      <section className="container px-5 py-[72px] md:px-10 md:py-[120px]">
         <h2 className="text-h2 text-blue-8 text-center flex flex-col">
           組別介紹
         </h2>

--- a/nextjs-app/components/pages/about/overview/GroupsIntro.tsx
+++ b/nextjs-app/components/pages/about/overview/GroupsIntro.tsx
@@ -23,7 +23,7 @@ const GroupsIntro = () => {
             imageSrc="/images/icon-lighthouse.png"
             enTitle="Philosophy"
             zhTitle="曼陀號理念"
-            buttonText="了解曼陀號理念"
+            buttonText="more"
             buttonLink={Routes.ABOUT.PHILOSOPHY}
             className="flex-1"
           />
@@ -31,7 +31,7 @@ const GroupsIntro = () => {
             imageSrc="/images/icon-duck.png"
             enTitle="Team"
             zhTitle="執行團隊"
-            buttonText="認識執行團隊"
+            buttonText="more"
             buttonLink={Routes.ABOUT.TEAM}
             className="flex-1"
           />

--- a/nextjs-app/components/pages/about/overview/GroupsIntro.tsx
+++ b/nextjs-app/components/pages/about/overview/GroupsIntro.tsx
@@ -1,0 +1,44 @@
+import GroupLabel from "@/components/common/GroupLabel";
+import { groupsInfo } from "@/constants/groups";
+import PageNavigationCard from "@/components/common/PageNavigationCard";
+import Routes from "@/constants/routes";
+
+const GroupsIntro = () => {
+  return (
+    <div className="w-full bg-neutral-1">
+      <section className="container px-3 py-[72px] md:px-10 md:py-[120px]">
+        <h2 className="text-h2 text-blue-8 text-center flex flex-col">
+          組別介紹
+        </h2>
+        <p className="text-body-md text-neutral-10 text-center mt-6">
+          依照學員職能領域共分為六大組別，月會也將依此分組進行
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-7 mt-11 mb-4 md:mb-7">
+          {groupsInfo.map((group) => (
+            <GroupLabel key={group.enGroupName} {...group} />
+          ))}
+        </div>
+        <div className="pt-[60px] lg:pt-[120px] flex flex-col lg:flex-row gap-7">
+          <PageNavigationCard
+            imageSrc="/images/icon-lighthouse.png"
+            enTitle="Philosophy"
+            zhTitle="曼陀號理念"
+            buttonText="了解曼陀號理念"
+            buttonLink={Routes.ABOUT.PHILOSOPHY}
+            className="flex-1"
+          />
+          <PageNavigationCard
+            imageSrc="/images/icon-duck.png"
+            enTitle="Team"
+            zhTitle="執行團隊"
+            buttonText="認識執行團隊"
+            buttonLink={Routes.ABOUT.TEAM}
+            className="flex-1"
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default GroupsIntro;

--- a/nextjs-app/components/pages/about/overview/MonthlyMeetingRoles.tsx
+++ b/nextjs-app/components/pages/about/overview/MonthlyMeetingRoles.tsx
@@ -35,7 +35,7 @@ const monthlyMeetingRolesData = [
 const MonthlyMeetingRoles = () => {
   return (
     <div className="w-full bg-yellow-1">
-      <section className="container px-3 py-[72px] md:px-11 md:py-[120px]">
+      <section className="container px-3 py-[72px] md:px-10 md:py-[120px]">
         <h2 className="text-h2 text-blue-8 text-center flex flex-col">
           月會運作方式
         </h2>

--- a/nextjs-app/components/pages/about/overview/MonthlyMeetingRoles.tsx
+++ b/nextjs-app/components/pages/about/overview/MonthlyMeetingRoles.tsx
@@ -35,7 +35,7 @@ const monthlyMeetingRolesData = [
 const MonthlyMeetingRoles = () => {
   return (
     <div className="w-full bg-yellow-1">
-      <section className="container px-3 py-[72px] md:px-10 md:py-[120px]">
+      <section className="container px-5 py-[72px] md:px-10 md:py-[120px]">
         <h2 className="text-h2 text-blue-8 text-center flex flex-col">
           月會運作方式
         </h2>

--- a/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
+++ b/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
@@ -37,7 +37,7 @@ const recruitmentTargetsData = [
 const RecruitmentTargets = () => {
   return (
     <div className="w-full bg-white">
-      <section className="container px-3 py-[72px] md:px-11 md:py-[120px]">
+      <section className="container px-3 py-[72px] md:px-10 md:py-[120px]">
         <h2 className="text-h2 text-blue-8 text-center flex flex-col">
           曼陀號計畫招募對象
         </h2>

--- a/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
+++ b/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
@@ -37,7 +37,7 @@ const recruitmentTargetsData = [
 const RecruitmentTargets = () => {
   return (
     <div className="w-full bg-white">
-      <section className="container px-3 py-[72px] md:px-10 md:py-[120px]">
+      <section className="container px-5 py-[72px] md:px-10 md:py-[120px]">
         <h2 className="text-h2 text-blue-8 text-center flex flex-col">
           曼陀號計畫招募對象
         </h2>


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #94 

## Changes made:

- `組別介紹` section in overview page
- create `PageNavigationCard` common component, which will also be used in philosophy page
- adjust padding in some sections

| Mobile | Tablet | Desktop |
|------|------------|-------|
| <img width="495" alt="截圖 2025-01-25 中午12 14 42" src="https://github.com/user-attachments/assets/86945d28-9f2c-48ee-82ea-cd7dfa2e03fb" /> | <img width="837" alt="截圖 2025-01-25 中午12 14 25" src="https://github.com/user-attachments/assets/f205f713-a563-4122-8d3a-1842862bdd8c" /> | <img width="1503" alt="截圖 2025-01-25 中午12 14 09" src="https://github.com/user-attachments/assets/fe8dd6ea-4708-438f-9a94-572098c6903d" /> |


## Test Scope / Change impact:

-
