### PR TITLE
feat: disabled style for button component

### DIFF
--- a/nextjs-app/components/common/Button/Button.tsx
+++ b/nextjs-app/components/common/Button/Button.tsx
@@ -39,8 +39,12 @@ const buttonClasses = cva(
         golden: "",
       },
       paddingSize: {
-        default: "p-5",
+        default: "py-5 px-7",
         "with-icon": "py-3 pl-4 pr-5",
+      },
+      disabled: {
+        true: "",
+        false: "",
       },
     },
     compoundVariants: [
@@ -56,6 +60,10 @@ const buttonClasses = cva(
         color: "golden",
         class: "text-yellow-6 border-yellow-6",
       },
+      {
+        disabled: true,
+        class: "bg-neutral-2 pointer-events-none text-neutral-5 border-none",
+      },
     ],
   }
 );
@@ -70,10 +78,15 @@ const dotClasses = cva("size-[14px] border-[5px] rounded-circle", {
       blue: "",
       golden: "",
     },
+    disabled: {
+      true: "",
+      false: "",
+    },
   },
   compoundVariants: [
     { variant: "outline", color: "blue", class: "border-blue-8" },
     { variant: "outline", color: "golden", class: "border-yellow-6" },
+    { disabled: true, class: "border-neutral-5" },
   ],
 });
 
@@ -89,14 +102,14 @@ const Button: FC<PropsWithChildren<ICallToActionLinkProps>> = ({
   return (
     <button
       className={twMerge(
-        buttonClasses({ variant, color, paddingSize }),
+        buttonClasses({ variant, color, paddingSize, disabled }),
         className
       )}
       disabled={disabled}
       onClick={onClick}
     >
       {children}
-      <span className={dotClasses({ variant, color })}></span>
+      <span className={dotClasses({ variant, color, disabled })}></span>
     </button>
   );
 };

--- a/nextjs-app/components/common/Button/RegisterNavigatorButton.tsx
+++ b/nextjs-app/components/common/Button/RegisterNavigatorButton.tsx
@@ -4,18 +4,32 @@ import Image from "next/image";
 import { twMerge } from "tailwind-merge";
 import Button from "./Button";
 
-const RegisterNavigatorButton: FC<{ className: string }> = ({ className }) => (
+interface IRegisterNavigatorButtonProps {
+  className?: string;
+  disabled?: boolean;
+}
+
+const RegisterNavigatorButton: FC<IRegisterNavigatorButtonProps> = ({
+  className,
+  disabled = false,
+}) => (
   <Button
     variant="outline"
     color="golden"
     paddingSize="with-icon"
     className={twMerge(className)}
+    disabled={disabled}
   >
     <Link
       href="/"
       className="w-[172px] flex justify-start items-center space-x-3"
     >
-      <div className="relative size-10 rounded-circle bg-yellow-6 overflow-hidden">
+      <div
+        className={twMerge(
+          "relative size-10 rounded-circle overflow-hidden",
+          disabled ? "bg-neutral-5" : "bg-yellow-6"
+        )}
+      >
         <Image
           fill
           src="/images/icon-navigator.png"

--- a/nextjs-app/components/common/Button/RegisterSailorButton.tsx
+++ b/nextjs-app/components/common/Button/RegisterSailorButton.tsx
@@ -4,18 +4,32 @@ import Image from "next/image";
 import { twMerge } from "tailwind-merge";
 import Button from "./Button";
 
-const RegisterSailorButton: FC<{ className: string }> = ({ className }) => (
+interface IRegisterSailorButtonProps {
+  className?: string;
+  disabled?: boolean;
+}
+
+const RegisterSailorButton: FC<IRegisterSailorButtonProps> = ({
+  className,
+  disabled = false,
+}) => (
   <Button
     variant="outline"
     color="blue"
     paddingSize="with-icon"
     className={twMerge(className)}
+    disabled={disabled}
   >
     <Link
       href="/"
       className="w-[172px] flex justify-start items-center space-x-3"
     >
-      <div className="relative size-10 rounded-circle bg-blue-8 overflow-hidden">
+      <div
+        className={twMerge(
+          "relative size-10 rounded-circle overflow-hidden",
+          disabled ? "bg-neutral-5" : "bg-blue-8"
+        )}
+      >
         <Image
           fill
           src="/images/icon-sailor.png"


### PR DESCRIPTION
## Why need this change? / Root cause:

- We will need to show disabled state before the registration starts

## Changes made:

- change correct default padding for button
- add disabled style for `Button`, `RegisterNavigatorButton`, `RegisterSailorButton`

<img width="441" alt="截圖 2025-01-27 凌晨12 00 58" src="https://github.com/user-attachments/assets/b31a84b8-20d7-4a35-96bc-d6fc25f6a96d" />


## Test Scope / Change impact:

-
