### PR TITLE
fix: header scroll issue on phone

### DIFF
--- a/nextjs-app/components/common/Header/Header.tsx
+++ b/nextjs-app/components/common/Header/Header.tsx
@@ -52,10 +52,12 @@ export default function Header() {
     const controlHeader = () => {
       const currentScrollY = window.scrollY;
 
-      if (currentScrollY < lastScrollY) {
+      if (currentScrollY < 50) {
         setIsVisible(true);
-      } else if (currentScrollY > lastScrollY) {
-        setIsVisible(false);
+      } else {
+        if (Math.abs(currentScrollY - lastScrollY) > 5) {
+          setIsVisible(currentScrollY < lastScrollY);
+        }
       }
 
       setIsAtTop(currentScrollY < 50);


### PR DESCRIPTION
## Why need this change? / Root cause:

The header will disappear on the top
(But this issue can only be reproduced on my phone, in the browser dev tool, all look good, not sure if this is because the difference between the scroll behaviors in each devices)

https://github.com/user-attachments/assets/d61468f7-83b9-4588-9643-c19da50489a3



## Changes made:

- if `window.scrollY` is less than 50, we just make sure the header will not be hided

## Test Scope / Change impact:

-
