### PR TITLE
feat: integrate posthog

### DIFF
--- a/nextjs-app/app/layout.tsx
+++ b/nextjs-app/app/layout.tsx
@@ -5,6 +5,7 @@ import Footer from "@/components/common/Footer";
 import Header from "@/components/common/Header";
 import { MENTORSHIP_WEBSITE_URL } from "@/constants/contact-info";
 import { METADATA } from "@/constants/metadata";
+import { CSPostHogProvider } from "@/providers/CSPostHogProvider";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -35,13 +36,15 @@ export default async function RootLayout({
       className={`font-sans ${ebGaramond.variable} bg-white text-black`}
     >
       <body>
-        <section className="min-h-screen pt-[80px] md:pt-[88px] lg:pt-[94px]">
-          <Header />
-          <main className="">{children}</main>
-          {/* TODO: enable floating buttons when the registration is open */}
-          {/* <FloatingButtons /> */}
-          <Footer />
-        </section>
+        <CSPostHogProvider>
+          <section className="min-h-screen pt-[80px] md:pt-[88px] lg:pt-[94px]">
+            <Header />
+            <main className="">{children}</main>
+            {/* TODO: enable floating buttons when the registration is open */}
+            {/* <FloatingButtons /> */}
+            <Footer />
+          </section>
+        </CSPostHogProvider>
       </body>
     </html>
   );

--- a/nextjs-app/components/common/PostHogPageView.tsx
+++ b/nextjs-app/components/common/PostHogPageView.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, Suspense } from "react";
+import { usePostHog } from "posthog-js/react";
+
+function PostHogPageView(): null {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (pathname) {
+      let url = window.origin + pathname;
+      if (searchParams.toString()) {
+        url = url + `?${searchParams.toString()}`;
+      }
+
+      posthog.capture("$pageview", { $current_url: url });
+    }
+  }, [pathname, searchParams, posthog]);
+
+  return null;
+}
+
+export default function SuspendedPostHogPageView() {
+  return (
+    <Suspense fallback={null}>
+      <PostHogPageView />
+    </Suspense>
+  );
+}

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -24,6 +24,7 @@
     "next": "^15.0.3",
     "next-sanity": "^9.8.11",
     "postcss": "^8.4.49",
+    "posthog-js": "^1.215.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "^3.63.0",

--- a/nextjs-app/pnpm-lock.yaml
+++ b/nextjs-app/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
+      posthog-js:
+        specifier: ^1.215.0
+        version: 1.215.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2260,6 +2263,9 @@ packages:
   core-js-compat@3.39.0:
     resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
 
+  core-js@3.40.0:
+    resolution: {integrity: sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -2789,6 +2795,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -4072,6 +4081,12 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.215.0:
+    resolution: {integrity: sha512-okdh+fOUZiWYMBmKd6Zm2rekgMAR8XdxinwFWlua6exx8IblKZuVO94OjQtoVAFwxmhH/i7UK/ANfohMeorS7Q==}
+
+  preact@10.25.4:
+    resolution: {integrity: sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5019,6 +5034,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -7583,6 +7601,8 @@ snapshots:
     dependencies:
       browserslist: 4.24.2
 
+  core-js@3.40.0: {}
+
   core-util-is@1.0.3: {}
 
   cosmiconfig@8.3.6(typescript@5.6.3):
@@ -8313,6 +8333,8 @@ snapshots:
   fdir@6.4.2(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fflate@0.4.8: {}
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -9575,6 +9597,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.215.0:
+    dependencies:
+      core-js: 3.40.0
+      fflate: 0.4.8
+      preact: 10.25.4
+      web-vitals: 4.2.4
+
+  preact@10.25.4: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.4.2: {}
@@ -10752,6 +10783,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-vitals@4.2.4: {}
 
   webidl-conversions@7.0.0: {}
 

--- a/nextjs-app/providers/CSPostHogProvider.tsx
+++ b/nextjs-app/providers/CSPostHogProvider.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { PropsWithChildren } from "react";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
+import PostHogPageView from "@/components/common/PostHogPageView";
+
+if (
+  typeof window !== "undefined" &&
+  process.env.NEXT_PUBLIC_POSTHOG_KEY &&
+  process.env.NEXT_PUBLIC_POSTHOG_HOST &&
+  process.env.NODE_ENV === "production"
+) {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: "identified_only",
+    // NOTE: because the special behavior in Next.js, we need to capture the events manually, ref: https://posthog.com/docs/libraries/next-js#capturing-pageviews
+    capture_pageview: false,
+    capture_pageleave: true,
+  });
+}
+
+export function CSPostHogProvider({ children }: PropsWithChildren) {
+  return (
+    <PostHogProvider client={posthog}>
+      <PostHogPageView />
+      {children}
+    </PostHogProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "tailwindcss": "^3.4.14",
     "typescript": "5.6.3",
     "class-variance-authority": "^0.7.1",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "posthog-js": "^1.215.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #123 

## Changes made:

- I choose [PostHog](https://posthog.com) as our solution, here is the reasons

  - Real-time event tracking → No delays in data processing.
  - Session replay → Watch user interactions directly.
  -  Feature flags & A/B testing → Built-in for product teams.
  - Developer-friendly API → Easier integration & customization.
 
To sum up, `PostHog` is ideal for product analytics, while GA4 is better for marketing & SEO tracking, although we only need  few features now, it will provide more possibilities for us in the future

- For the integration code, I mainly refer to [the official doc](https://posthog.com/docs/libraries/next-js)
- Only enable the analytics in prod mode, the screenshot is for demo purpose 

## Result Demo


https://github.com/user-attachments/assets/48768210-17aa-4ffd-9015-7b8380121f33

