### PR TITLE
enhancement: show boat icon on each device & remove priority prop on boat png

### DIFF
--- a/nextjs-app/components/pages/about/philosophy/ProgramIntroduction.tsx
+++ b/nextjs-app/components/pages/about/philosophy/ProgramIntroduction.tsx
@@ -29,7 +29,7 @@ const ProgramIntroduction = () => (
         alt="icon-ship"
         width={48}
         height={48}
-        className="hidden lg:block absolute right-[96px] -translate-y-1/2"
+        className="absolute right-11 -translate-y-2/3 md:right-[96px] md:-translate-y-1/2 motion-translate-y-loop-[4px] motion-duration-2000 motion-ease-in-out"
       />
       <div className="w-full flex flex-col justify-center mb-11 p-7 md:p-11 bg-white rounded-3">
         <div className="w-full mx-auto">

--- a/nextjs-app/components/pages/main/Banner.tsx
+++ b/nextjs-app/components/pages/main/Banner.tsx
@@ -81,7 +81,6 @@ const Banner = () => (
         src="/images/index-banner/boat.png"
         alt="boat"
         fill
-        priority
         sizes="auto"
         className={twMerge(
           "hidden lg:block translate-y-[-50px]",


### PR DESCRIPTION
## Why need this change? / Root cause:

- close #132 

## Changes made:

<img width="575" alt="截圖 2025-02-05 下午5 38 35" src="https://github.com/user-attachments/assets/7ea107e7-f125-48db-aa7a-ebb756e4b06b" />
<img width="856" alt="截圖 2025-02-05 下午5 38 46" src="https://github.com/user-attachments/assets/77a20851-660b-4b53-975b-0db0fa82e012" />

- also remove the `priority` prop on boat.png because I just notice that only lg screen need this image. If we add this property, all the device will preload the image

## Test Scope / Change impact:

-
