### PR TITLE
fix: correct timezone display on Activity page

### DIFF
--- a/nextjs-app/utils/activity.ts
+++ b/nextjs-app/utils/activity.ts
@@ -31,6 +31,7 @@ const formatDate = (date: Date) =>
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
+    timeZone: "Asia/Taipei",
   });
 
 const formatTime = (date: Date) =>
@@ -38,6 +39,7 @@ const formatTime = (date: Date) =>
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
+    timeZone: "Asia/Taipei",
   });
 
 const lectureTimeToString = (


### PR DESCRIPTION
## Why need this change? / Root cause:

- The time display was affected by the user's local timezone.
- However, the intended behavior is to display times in `Taipei Time`.

![Screenshot 2025-06-14 at 9 07 38 PM](https://github.com/user-attachments/assets/f5b95152-273a-44a8-a7c4-1dbb404c35df)

## Changes made:

- Updated the time formatting logic to explicitly display time in the Asia/Taipei timezone.

## Test Scope / Change impact:

- `/activity`
