### PR TITLE
fix(security): upgrade Next.js to 15.3.8 to patch 4 CVEs

### DIFF
--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -23,7 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "date-fns": "^3.6.0",
     "lodash": "^4.17.21",
-    "next": "15.3.3",
+    "next": "15.3.8",
     "next-sanity": "9.12.0",
     "postcss": "^8.4.49",
     "posthog-js": "^1.215.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "date-fns": "^3.6.0",
     "lodash": "^4.17.21",
-    "next": "15.3.3",
+    "next": "15.3.8",
     "next-sanity": "9.12.0",
     "postcss": "^8.4.49",
     "posthog-js": "^1.215.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 18.3.3(@types/react@18.3.14)
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.3.3)(react@18.3.1)
+        version: 1.1.0(next@15.3.8)(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -51,11 +51,11 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       next:
-        specifier: 15.3.3
-        version: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+        specifier: 15.3.8
+        version: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       next-sanity:
         specifier: 9.12.0
-        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.3)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
+        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -146,7 +146,7 @@ importers:
         version: 18.3.3(@types/react@18.3.14)
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.3.3)(react@18.3.1)
+        version: 1.1.0(next@15.3.8)(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -160,11 +160,11 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       next:
-        specifier: 15.3.3
-        version: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+        specifier: 15.3.8
+        version: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       next-sanity:
         specifier: 9.12.0
-        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.3)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
+        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
     dev: false
 
-  /@next/env@15.3.3:
-    resolution: {integrity: sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==}
+  /@next/env@15.3.8:
+    resolution: {integrity: sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q==}
     dev: false
 
   /@next/eslint-plugin-next@15.0.4:
@@ -2791,8 +2791,8 @@ packages:
       fast-glob: 3.3.1
     dev: true
 
-  /@next/swc-darwin-arm64@15.3.3:
-    resolution: {integrity: sha512-WRJERLuH+O3oYB4yZNVahSVFmtxRNjNF1I1c34tYMoJb0Pve+7/RaLAJJizyYiFhjYNGHRAE1Ri2Fd23zgDqhg==}
+  /@next/swc-darwin-arm64@15.3.5:
+    resolution: {integrity: sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2800,8 +2800,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64@15.3.3:
-    resolution: {integrity: sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw==}
+  /@next/swc-darwin-x64@15.3.5:
+    resolution: {integrity: sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2809,8 +2809,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@15.3.3:
-    resolution: {integrity: sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw==}
+  /@next/swc-linux-arm64-gnu@15.3.5:
+    resolution: {integrity: sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2818,8 +2818,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl@15.3.3:
-    resolution: {integrity: sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==}
+  /@next/swc-linux-arm64-musl@15.3.5:
+    resolution: {integrity: sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2827,8 +2827,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@15.3.3:
-    resolution: {integrity: sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==}
+  /@next/swc-linux-x64-gnu@15.3.5:
+    resolution: {integrity: sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2836,8 +2836,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl@15.3.3:
-    resolution: {integrity: sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==}
+  /@next/swc-linux-x64-musl@15.3.5:
+    resolution: {integrity: sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2845,8 +2845,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@15.3.3:
-    resolution: {integrity: sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==}
+  /@next/swc-win32-arm64-msvc@15.3.5:
+    resolution: {integrity: sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2854,8 +2854,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc@15.3.3:
-    resolution: {integrity: sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw==}
+  /@next/swc-win32-x64-msvc@15.3.5:
+    resolution: {integrity: sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3717,7 +3717,7 @@ packages:
       - supports-color
     dev: false
 
-  /@sanity/next-loader@1.6.2(@sanity/types@3.90.0)(next@15.3.3)(react@18.3.1):
+  /@sanity/next-loader@1.6.2(@sanity/types@3.90.0)(next@15.3.8)(react@18.3.1):
     resolution: {integrity: sha512-PF4L0p7Zi39n0b3LUuKkEKE8+ZgaBOfTHRmzSiivgafM5GgTKU9nnx9YLwXyo9UUpPZPjzvpuom5bo+zF5zZKg==}
     engines: {node: '>=18.18'}
     peerDependencies:
@@ -3728,7 +3728,7 @@ packages:
       '@sanity/comlink': 3.0.5
       '@sanity/presentation-comlink': 1.0.21(@sanity/client@7.1.0)(@sanity/types@3.90.0)
       dequal: 2.0.3
-      next: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       use-effect-event: 1.0.2(react@18.3.1)
     transitivePeerDependencies:
@@ -4095,7 +4095,7 @@ packages:
       '@sanity/types': 3.90.0(@types/react@18.3.14)(debug@4.4.1)
     dev: false
 
-  /@sanity/visual-editing@2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.3)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3):
+  /@sanity/visual-editing@2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3):
     resolution: {integrity: sha512-l9MrudT4cvLjvDRlLSFSn4/JuQqQ25uQKP/NDSxPB18WQzDms2DqilLJVtLHoW1PeY3UQWMseAsFr9kqzG4vTQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -4134,7 +4134,7 @@ packages:
       '@sanity/visual-editing-csm': 2.0.18(@sanity/client@7.1.0)(@sanity/types@3.90.0)(typescript@5.6.3)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
-      next: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-compiler-runtime: 19.1.0-rc.2(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -4867,7 +4867,7 @@ packages:
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
     dev: true
 
-  /@vercel/speed-insights@1.1.0(next@15.3.3)(react@18.3.1):
+  /@vercel/speed-insights@1.1.0(next@15.3.8)(react@18.3.1):
     resolution: {integrity: sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==}
     requiresBuild: true
     peerDependencies:
@@ -4891,7 +4891,7 @@ packages:
       vue-router:
         optional: true
     dependencies:
-      next: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
     dev: false
 
@@ -8886,7 +8886,7 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next-sanity@9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.3)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3):
+  /next-sanity@9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3):
     resolution: {integrity: sha512-h9j2WA0M19jhnXZSet8JMugf8zGWyx9j586VVPcntbI/LUnFvWxzZEi+tXtS/SELJDSA6xxhOu8JpUZDo7ltWw==}
     engines: {node: '>=18.18'}
     peerDependencies:
@@ -8903,15 +8903,15 @@ packages:
       '@portabletext/react': 3.2.1(react@18.3.1)
       '@sanity/client': 7.1.0
       '@sanity/icons': 3.7.0(react@18.3.1)
-      '@sanity/next-loader': 1.6.2(@sanity/types@3.90.0)(next@15.3.3)(react@18.3.1)
+      '@sanity/next-loader': 1.6.2(@sanity/types@3.90.0)(next@15.3.8)(react@18.3.1)
       '@sanity/preview-kit': 6.1.1(@sanity/types@3.90.0)(react@18.3.1)
       '@sanity/preview-url-secret': 2.1.11(@sanity/client@7.1.0)
       '@sanity/types': 3.90.0(@types/react@18.3.14)(debug@4.4.1)
       '@sanity/ui': 2.15.18(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)
-      '@sanity/visual-editing': 2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.3)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3)
+      '@sanity/visual-editing': 2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3)
       groq: 3.90.0
       history: 5.3.0
-      next: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sanity: 3.90.0(@types/node@20.17.9)(@types/react@18.3.14)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3)
@@ -8927,8 +8927,8 @@ packages:
       - typescript
     dev: false
 
-  /next@15.3.3(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==}
+  /next@15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -8948,7 +8948,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 15.3.3
+      '@next/env': 15.3.8
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -8958,14 +8958,14 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.27.4)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.3.3
-      '@next/swc-darwin-x64': 15.3.3
-      '@next/swc-linux-arm64-gnu': 15.3.3
-      '@next/swc-linux-arm64-musl': 15.3.3
-      '@next/swc-linux-x64-gnu': 15.3.3
-      '@next/swc-linux-x64-musl': 15.3.3
-      '@next/swc-win32-arm64-msvc': 15.3.3
-      '@next/swc-win32-x64-msvc': 15.3.3
+      '@next/swc-darwin-arm64': 15.3.5
+      '@next/swc-darwin-x64': 15.3.5
+      '@next/swc-linux-arm64-gnu': 15.3.5
+      '@next/swc-linux-arm64-musl': 15.3.5
+      '@next/swc-linux-x64-gnu': 15.3.5
+      '@next/swc-linux-x64-musl': 15.3.5
+      '@next/swc-win32-arm64-msvc': 15.3.5
+      '@next/swc-win32-x64-msvc': 15.3.5
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
## 🚨 安全修補

升級 Next.js 從 **15.3.3** 至 **15.3.8**，修補 4 個安全漏洞。

**關聯 Issue**: Closes #204

---

## Why need this change? / Root cause:

專案目前使用 Next.js 15.3.3，經 `npx fix-react2shell-next` 掃描發現受到 4 個安全漏洞影響：

1. **CVE-2025-66478** (🔴 Critical) - 遠端程式碼執行 via crafted RSC payload
2. **CVE-2025-55184** (🟠 High) - DoS via malicious HTTP request causing server hang
3. **CVE-2025-55183** (🟡 Medium) - Compiled Server Action source code exposure
4. **CVE-2025-67779** (🟠 High) - Incomplete fix for CVE-2025-55184 DoS

由於專案使用 **App Router + React Server Components**，符合所有受影響條件，需立即升級修補。

**官方公告**: https://nextjs.org/blog/CVE-2025-66478

---

## Changes made:

- ✅ Next.js: `15.3.3` → `15.3.8`
- ✅ 使用官方工具 `npx fix-react2shell-next` 自動修補
- ✅ 更新 `nextjs-app/package.json`
- ✅ 更新根目錄 `package.json`
- ✅ 更新 `pnpm-lock.yaml`

**驗證結果**:
npx fix-react2shell-next
# ✅ No vulnerable packages found!
