### PR TITLE
feat: hide 7th activity, patch CVE-2026-23864, upgrade next to 15.3.9

### DIFF
--- a/nextjs-app/app/activity/page.tsx
+++ b/nextjs-app/app/activity/page.tsx
@@ -1,19 +1,19 @@
-import { client } from "@/sanity/lib/client";
-import {
-  AllActivitiesQueryResult,
-  AllActivityCategoriesQueryResult,
-} from "@/sanity.types";
-import {
-  allActivitiesQuery,
-  allActivityCategoriesQuery,
-} from "@/sanity/lib/queries";
+// import { client } from "@/sanity/lib/client";
+// import {
+//   AllActivitiesQueryResult,
+//   AllActivityCategoriesQueryResult,
+// } from "@/sanity.types";
+// import {
+//   allActivitiesQuery,
+//   allActivityCategoriesQuery,
+// } from "@/sanity/lib/queries";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import MarqueeTitle from "@/components/common/MarqueeTitle";
-import ContentWithFilter from "@/components/pages/activity/ContentWithFilter";
+// import ContentWithFilter from "@/components/pages/activity/ContentWithFilter";
 import Routes from "@/constants/routes";
-import { IFilterOption } from "@/types/filter-option";
-import { ActivityInfo } from "@/types/activity";
-import { toActivitiesUI } from "@/utils/activity";
+// import { IFilterOption } from "@/types/filter-option";
+// import { ActivityInfo } from "@/types/activity";
+// import { toActivitiesUI } from "@/utils/activity";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -24,31 +24,32 @@ export const metadata: Metadata = {
 };
 
 export default async function ActivityPage() {
-  const activityCategoriesFromApi =
-    await client.fetch<AllActivityCategoriesQueryResult>(
-      allActivityCategoriesQuery
-    );
+  // const activityCategoriesFromApi =
+  //   await client.fetch<AllActivityCategoriesQueryResult>(
+  //     allActivityCategoriesQuery
+  //   );
 
-  const activitiesFromApi =
-    await client.fetch<AllActivitiesQueryResult>(allActivitiesQuery);
+  // const activitiesFromApi =
+  //   await client.fetch<AllActivitiesQueryResult>(allActivitiesQuery);
 
-  const filterOptions: IFilterOption[] = [{ key: "all", name: "全部" }].concat(
-    activityCategoriesFromApi.map(({ key, value }) => ({
-      key,
-      name: value,
-    }))
-  );
+  // const filterOptions: IFilterOption[] = [{ key: "all", name: "全部" }].concat(
+  //   activityCategoriesFromApi.map(({ key, value }) => ({
+  //     key,
+  //     name: value,
+  //   }))
+  // );
 
-  const activities: ActivityInfo[] = toActivitiesUI(activitiesFromApi);
+  // const activities: ActivityInfo[] = toActivitiesUI(activitiesFromApi);
 
   return (
     <div>
       <Breadcrumb items={["HOME", "活動內容"]} />
       <MarqueeTitle zhTitle="活動內容" enTitle="Activity" />
-      <ContentWithFilter
+      {/* 暫時隱藏，之後 Sanity 更新資料完畢再恢復 */}
+      {/* <ContentWithFilter
         filterOptions={filterOptions}
         activities={activities}
-      />
+      /> */}
     </div>
   );
 }

--- a/nextjs-app/components/pages/about/overview/MarqueeImage.tsx
+++ b/nextjs-app/components/pages/about/overview/MarqueeImage.tsx
@@ -20,7 +20,7 @@ const MarqueeImage: FC = () => {
     <div className="bg-white py-[120px] relative">
       <Wave color="white" />
       <div className="container text-center">
-        <h2 className="text-h2 text-blue-8">第七屆引水人們想傳達的話</h2>
+        <h2 className="text-h2 text-blue-8">引水人們想傳達的話</h2>
 
         <p className="text-subtitle-lg text-neutral-8 mt-7">
           我們求新求變，不斷打磨

--- a/nextjs-app/components/pages/program-rules/ProgramFees.tsx
+++ b/nextjs-app/components/pages/program-rules/ProgramFees.tsx
@@ -19,6 +19,9 @@ const FEE_DATA = [
   },
 ];
 
+const FEE_NOTICE =
+  "費用每年依活動規模、場地與課程設計進行動態調整，請以當屆公告為準。";
+
 interface IFeeInfo {
   imageSrc: string;
   title: string;
@@ -59,7 +62,7 @@ const ProgramFees = () => (
     <Wave color="blue8" />
     <div className="container px-5 py-[72px] md:px-10 md:py-[120px]">
       <SectionTitle
-        title="計劃參加費用"
+        title="2025 第 7 屆計劃參加費用"
         description={`「收到海選通知信」始需繳納「海選參加費」\n「收到錄取通知信」始需繳納「計劃報名費」`}
         serial="06"
         variant="dark"
@@ -74,6 +77,12 @@ const ProgramFees = () => (
             fee={item.fee}
           />
         ))}
+      </div>
+      <div className="mt-6 md:mt-8 rounded-2 border border-blue-3/50 bg-blue-7/70 px-4 py-3 md:px-6 md:py-4">
+        <p className="text-body-sm md:text-body-md text-white/90 leading-relaxed">
+          <span className="font-semibold text-yellow-3">註：</span>
+          {FEE_NOTICE}
+        </p>
       </div>
     </div>
   </section>

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -23,7 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "date-fns": "^3.6.0",
     "lodash": "^4.17.21",
-    "next": "15.3.8",
+    "next": "15.3.9",
     "next-sanity": "9.12.0",
     "postcss": "^8.4.49",
     "posthog-js": "^1.215.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "date-fns": "^3.6.0",
     "lodash": "^4.17.21",
-    "next": "15.3.8",
+    "next": "15.3.9",
     "next-sanity": "9.12.0",
     "postcss": "^8.4.49",
     "posthog-js": "^1.215.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 18.3.3(@types/react@18.3.14)
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.3.8)(react@18.3.1)
+        version: 1.1.0(next@15.3.9)(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -51,11 +51,11 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       next:
-        specifier: 15.3.8
-        version: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+        specifier: 15.3.9
+        version: 15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       next-sanity:
         specifier: 9.12.0
-        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
+        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.9)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -146,7 +146,7 @@ importers:
         version: 18.3.3(@types/react@18.3.14)
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.3.8)(react@18.3.1)
+        version: 1.1.0(next@15.3.9)(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -160,11 +160,11 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       next:
-        specifier: 15.3.8
-        version: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+        specifier: 15.3.9
+        version: 15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       next-sanity:
         specifier: 9.12.0
-        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
+        version: 9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.9)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
     dev: false
 
-  /@next/env@15.3.8:
-    resolution: {integrity: sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q==}
+  /@next/env@15.3.9:
+    resolution: {integrity: sha512-I7wMCjlHc85EvAebNYJCRBZ+shdrGhcIXBviWmDzGYXwTQ+WrYpfg1LBOnTK1Bn3b+ud5apesNObXKEGqi/C3g==}
     dev: false
 
   /@next/eslint-plugin-next@15.0.4:
@@ -3717,7 +3717,7 @@ packages:
       - supports-color
     dev: false
 
-  /@sanity/next-loader@1.6.2(@sanity/types@3.90.0)(next@15.3.8)(react@18.3.1):
+  /@sanity/next-loader@1.6.2(@sanity/types@3.90.0)(next@15.3.9)(react@18.3.1):
     resolution: {integrity: sha512-PF4L0p7Zi39n0b3LUuKkEKE8+ZgaBOfTHRmzSiivgafM5GgTKU9nnx9YLwXyo9UUpPZPjzvpuom5bo+zF5zZKg==}
     engines: {node: '>=18.18'}
     peerDependencies:
@@ -3728,7 +3728,7 @@ packages:
       '@sanity/comlink': 3.0.5
       '@sanity/presentation-comlink': 1.0.21(@sanity/client@7.1.0)(@sanity/types@3.90.0)
       dequal: 2.0.3
-      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       use-effect-event: 1.0.2(react@18.3.1)
     transitivePeerDependencies:
@@ -4095,7 +4095,7 @@ packages:
       '@sanity/types': 3.90.0(@types/react@18.3.14)(debug@4.4.1)
     dev: false
 
-  /@sanity/visual-editing@2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3):
+  /@sanity/visual-editing@2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.9)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3):
     resolution: {integrity: sha512-l9MrudT4cvLjvDRlLSFSn4/JuQqQ25uQKP/NDSxPB18WQzDms2DqilLJVtLHoW1PeY3UQWMseAsFr9kqzG4vTQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -4134,7 +4134,7 @@ packages:
       '@sanity/visual-editing-csm': 2.0.18(@sanity/client@7.1.0)(@sanity/types@3.90.0)(typescript@5.6.3)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
-      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-compiler-runtime: 19.1.0-rc.2(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -4867,7 +4867,7 @@ packages:
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
     dev: true
 
-  /@vercel/speed-insights@1.1.0(next@15.3.8)(react@18.3.1):
+  /@vercel/speed-insights@1.1.0(next@15.3.9)(react@18.3.1):
     resolution: {integrity: sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==}
     requiresBuild: true
     peerDependencies:
@@ -4891,7 +4891,7 @@ packages:
       vue-router:
         optional: true
     dependencies:
-      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
     dev: false
 
@@ -8886,7 +8886,7 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next-sanity@9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3):
+  /next-sanity@9.12.0(@sanity/client@7.1.0)(@sanity/icons@3.7.0)(@sanity/types@3.90.0)(@sanity/ui@2.15.18)(next@15.3.9)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(sanity@3.90.0)(styled-components@6.1.18)(typescript@5.6.3):
     resolution: {integrity: sha512-h9j2WA0M19jhnXZSet8JMugf8zGWyx9j586VVPcntbI/LUnFvWxzZEi+tXtS/SELJDSA6xxhOu8JpUZDo7ltWw==}
     engines: {node: '>=18.18'}
     peerDependencies:
@@ -8903,15 +8903,15 @@ packages:
       '@portabletext/react': 3.2.1(react@18.3.1)
       '@sanity/client': 7.1.0
       '@sanity/icons': 3.7.0(react@18.3.1)
-      '@sanity/next-loader': 1.6.2(@sanity/types@3.90.0)(next@15.3.8)(react@18.3.1)
+      '@sanity/next-loader': 1.6.2(@sanity/types@3.90.0)(next@15.3.9)(react@18.3.1)
       '@sanity/preview-kit': 6.1.1(@sanity/types@3.90.0)(react@18.3.1)
       '@sanity/preview-url-secret': 2.1.11(@sanity/client@7.1.0)
       '@sanity/types': 3.90.0(@types/react@18.3.14)(debug@4.4.1)
       '@sanity/ui': 2.15.18(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)
-      '@sanity/visual-editing': 2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.8)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3)
+      '@sanity/visual-editing': 2.15.0(@sanity/client@7.1.0)(@sanity/types@3.90.0)(next@15.3.9)(react-dom@18.3.1)(react-is@19.1.0)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3)
       groq: 3.90.0
       history: 5.3.0
-      next: 15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
+      next: 15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sanity: 3.90.0(@types/node@20.17.9)(@types/react@18.3.14)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.18)(typescript@5.6.3)
@@ -8927,8 +8927,8 @@ packages:
       - typescript
     dev: false
 
-  /next@15.3.8(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==}
+  /next@15.3.9(@babel/core@7.27.4)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-bat50ogkh2esjfkbqmVocL5QunR9RGCSO2oQKFjKeDcEylIgw3JY6CMfGnzoVfXJ9SDLHI546sHmsk90D2ivwQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -8948,7 +8948,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 15.3.8
+      '@next/env': 15.3.9
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0


### PR DESCRIPTION
## Why need this change? / Root cause:

This PR includes several maintenance and security updates:

1. The 7th activity should no longer be visible on the activity page based on current business requirements.
2. The project is using an older Next.js version with known security vulnerabilities (CVE-2026-23864).
3. Upgrade Next.js to the latest patch version to address vulnerabilities and improve stability.


---

## Changes made:

### Activity
- Temporarily comment out ContentWithFilter component to hide 7th activity

/activity
<img width="1440" height="688" alt="image" src="https://github.com/user-attachments/assets/5bf4000d-ad96-4691-ae64-a3bf2042c360" />
/program-rules
<img width="1436" height="683" alt="image" src="https://github.com/user-attachments/assets/01df6a06-0af8-4864-8fbf-5a178d25dfc1" />
/about/overview
<img width="1436" height="683" alt="image" src="https://github.com/user-attachments/assets/b683d7cc-34ca-469e-b3d9-5f949920aebf" />

### Security
- Patch CVE-2026-23864 vulnerability

### Dependencies
- Upgrade Next.js: `15.3.8 → 15.3.9`
- Update `package.json`
- Update lock file

---

## Test Scope / Change impact:

### Pages affected
- /activity
- /program-rules
- /about/overview

### Verify
- 7th activity is not displayed
- Other activities render normally
- App builds and runs successfully
- No console errors
- Basic navigation and page rendering work as expected

### Risk
- Low (component temporarily disabled + dependency patch upgrade only, no schema or API changes)
