### PR TITLE
feat: update schedule details for the 8th attendee

### DIFF
--- a/nextjs-app/constants/schedules.tsx
+++ b/nextjs-app/constants/schedules.tsx
@@ -88,7 +88,7 @@ export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
       tag: "日期地點依各組公布為主",
       title: "第八屆曼陀號領航計劃 主要活動期間",
       description:
-        "包含 (各組月會四場 + 通識主題講座七場 + 不定期跨職能與跨屆交流) x 無限可能！",
+        "包含 (各組月會四場 + 通識主題講座四場 + 不定期跨職能與跨屆交流) x 無限可能！",
     },
   },
   {


### PR DESCRIPTION
## Why need this change? / Root cause:
- update the lastest schedule for the 8th attendee
- related tasks: 
[[活動辦法][水手報名流程] 時程資料置換](https://www.notion.so/2f5cb9ed6c788168abfcff2a73336eeb?source=copy_link)
[[活動辦法][航海士報名流程] 時程資料置換](https://www.notion.so/2f5cb9ed6c7881cea679c231ba35b3e8?source=copy_link)

## Changes made:
all in `/program-rules`
### Sailor
<img width="919" height="836" alt="螢幕截圖 2026-02-06 晚上11 52 32" src="https://github.com/user-attachments/assets/24bde3da-677e-426e-b334-c99504af0934" />

### Navigator
<img width="884" height="947" alt="螢幕截圖 2026-02-06 晚上11 52 41" src="https://github.com/user-attachments/assets/522ac872-52e9-4c02-9a22-808817964851" />


## Test Scope / Change impact:
### Pages affected
- `/program-rules`

### Risk
- Low
