### PR TITLE
feat: remove registration links

### DIFF
--- a/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
+++ b/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
@@ -12,8 +12,8 @@ const recruitmentTargetsData = [
     buttonText: "馬上報名水手",
     buttonColor: "blue" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "https://forms.gle/upPsjEssy4nAJTAW8",
-    buttonDisabled: false,
+    externalLink: "",
+    buttonDisabled: true,
   },
   {
     title: "Navigator\n航海士 (職場前輩)",
@@ -23,8 +23,8 @@ const recruitmentTargetsData = [
     buttonText: "馬上報名航海士",
     buttonColor: "golden" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "https://forms.gle/upPsjEssy4nAJTAW8",
-    buttonDisabled: false,
+    externalLink: "",
+    buttonDisabled: true,
   },
   {
     title: "Captain\n船長 (導師)",

--- a/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
+++ b/nextjs-app/components/pages/about/overview/RecruitmentTargets.tsx
@@ -12,7 +12,6 @@ const recruitmentTargetsData = [
     buttonText: "馬上報名水手",
     buttonColor: "blue" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "",
     buttonDisabled: true,
   },
   {
@@ -23,7 +22,6 @@ const recruitmentTargetsData = [
     buttonText: "馬上報名航海士",
     buttonColor: "golden" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "",
     buttonDisabled: true,
   },
   {

--- a/nextjs-app/components/pages/main/Banner.tsx
+++ b/nextjs-app/components/pages/main/Banner.tsx
@@ -117,8 +117,8 @@ const Banner = () => (
             <CountdownTimer />
           </div> */}
           <div className="w-fit flex flex-col justify-center gap-4 mt-7">
-            <RegisterSailorButton disabled={false} />
-            <RegisterNavigatorButton disabled={false} />
+            <RegisterSailorButton disabled />
+            <RegisterNavigatorButton disabled />
           </div>
         </div>
       </div>

--- a/nextjs-app/constants/registration.ts
+++ b/nextjs-app/constants/registration.ts
@@ -1,1 +1,1 @@
-export const REGISTRATION_FORM_URL = "https://forms.gle/upPsjEssy4nAJTAW8";
+export const REGISTRATION_FORM_URL = "";

--- a/nextjs-app/constants/schedules.tsx
+++ b/nextjs-app/constants/schedules.tsx
@@ -209,7 +209,7 @@ export const SCHEDULE_ROLE_DATA = [
     buttonText: "馬上報名水手",
     buttonColor: "blue" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "",
+    externalLink: undefined,
     buttonDisabled: true,
   },
   {
@@ -220,7 +220,7 @@ export const SCHEDULE_ROLE_DATA = [
     buttonText: "馬上報名航海士",
     buttonColor: "golden" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "",
+    externalLink: undefined,
     buttonDisabled: true,
   },
 ];

--- a/nextjs-app/constants/schedules.tsx
+++ b/nextjs-app/constants/schedules.tsx
@@ -209,8 +209,8 @@ export const SCHEDULE_ROLE_DATA = [
     buttonText: "馬上報名水手",
     buttonColor: "blue" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "https://forms.gle/upPsjEssy4nAJTAW8",
-    buttonDisabled: false,
+    externalLink: "",
+    buttonDisabled: true,
   },
   {
     title: "Navigator\n航海士 (職場前輩)",
@@ -220,8 +220,8 @@ export const SCHEDULE_ROLE_DATA = [
     buttonText: "馬上報名航海士",
     buttonColor: "golden" as ButtonColor,
     buttonClassName: "px-7",
-    externalLink: "https://forms.gle/upPsjEssy4nAJTAW8",
-    buttonDisabled: false,
+    externalLink: "",
+    buttonDisabled: true,
   },
 ];
 


### PR DESCRIPTION
### 下架第 8 屆報名連結
related tasks: 
1. [[活動辦法][報名連結] 下架](https://www.notion.so/Project-Task-Tracker-31f3af684bf880bdaa49ee80a816bdc9?p=31f3af684bf88193988cc5f504ebaaeb&pm=s)
2. [[首頁][報名連結]下架](https://www.notion.so/31f3af684bf8818bade1ec5bf1b74023?source=copy_link)
3. [[關於曼陀號 - 計劃介紹][計劃招募對象] 報名連結下架](https://www.notion.so/31f3af684bf8819a88f1f20fa6d8ce05?source=copy_link)

Why need this change? / Root cause:
第 8 屆計劃報名截止，需下架報名連結

Changes made:
✅ [活動辦法] 禁用行程表水手 / 航海士報名按鈕
✅ [首頁]  禁用 Banner 水手 / 航海士報名按鈕
✅ [關於曼陀號 - 計劃介紹]  禁用計劃招募對象報名按鈕
✅ 移除報名連結 constants/registration.ts

## Test Scope / Change impact:
low
