### PR TITLE
fix: boat image should be placed in current month

### DIFF
--- a/nextjs-app/constants/schedules.tsx
+++ b/nextjs-app/constants/schedules.tsx
@@ -1,14 +1,18 @@
 import { ButtonColor } from "@/components/common/Button/Button";
 import {
   IScheduleDetail,
-  SchedulePhase,
   IScheduleStep,
   ScheduleType,
 } from "@/types/schedule";
+import { getSchedulePhaseByDateTimeIndex } from "@/utils/schedule";
 
-export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
+type IScheduleDetailWithoutPhase = Omit<IScheduleDetail, "phase"> & {
+  dateTimeIndex: number[];
+};
+
+const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [2, 3],
     type: ScheduleType.DEFAULT,
     timeline: {
       title: "2月 - 3月",
@@ -26,7 +30,7 @@ export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
     },
   },
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [3],
     type: ScheduleType.DEFAULT,
     timeline: {
       title: "3 月",
@@ -38,28 +42,30 @@ export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
         title: "面試名單揭曉",
         description: "屆時將寄信通知第一階段審核結果",
       },
-      {
-        date: "2026/04/13 (Mon) - 2026/04/17 (Fri)",
-        title: "線上面試",
-        description: "進行第二階段面試複審",
-      },
     ],
   },
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [4],
     type: ScheduleType.DEFAULT,
     timeline: {
       title: "4 月",
       description: "(面試複審)",
     },
-    event: {
-      date: "2026/04/19 (Sun)",
-      title: "面試結果揭曉",
-      description: "屆時將寄信通知第二階段審核結果，通過者得以進入海選",
-    },
+    event: [
+      {
+        date: "2026/04/13 (Mon) - 2026/04/17 (Fri)",
+        title: "線上面試",
+        description: "進行第二階段面試複審",
+      },
+      {
+        date: "2026/04/19 (Sun)",
+        title: "面試結果揭曉",
+        description: "屆時將寄信通知第二階段審核結果，通過者得以進入海選",
+      },
+    ],
   },
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [5],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "5月",
@@ -82,7 +88,7 @@ export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
     ],
   },
   {
-    phase: SchedulePhase.ONGOING,
+    dateTimeIndex: [6, 9],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "6月 - 9月",
@@ -97,7 +103,7 @@ export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
     },
   },
   {
-    phase: SchedulePhase.ACTIVE,
+    dateTimeIndex: [11],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "11月",
@@ -112,9 +118,19 @@ export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
   },
 ];
 
-export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
+export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] =
+  SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW.map((detail) => {
+    const { dateTimeIndex, ...scheduleDetail } = detail;
+
+    return {
+      ...scheduleDetail,
+      phase: getSchedulePhaseByDateTimeIndex(dateTimeIndex),
+    };
+  });
+
+const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [2, 3],
     type: ScheduleType.DEFAULT,
     timeline: {
       title: "2月 - 3月",
@@ -132,7 +148,7 @@ export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
     },
   },
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [4],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "4月",
@@ -147,7 +163,7 @@ export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
     ],
   },
   {
-    phase: SchedulePhase.EXPIRED,
+    dateTimeIndex: [5],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "5月",
@@ -170,7 +186,7 @@ export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
     ],
   },
   {
-    phase: SchedulePhase.ONGOING,
+    dateTimeIndex: [6, 9],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "6月 - 9月",
@@ -185,7 +201,7 @@ export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
     },
   },
   {
-    phase: SchedulePhase.ACTIVE,
+    dateTimeIndex: [11],
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "11月",
@@ -199,6 +215,16 @@ export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
     },
   },
 ];
+
+export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] =
+  SCHEDULE_DETAIL_DATA_SAILOR_RAW.map((detail) => {
+    const { dateTimeIndex, ...scheduleDetail } = detail;
+
+    return {
+      ...scheduleDetail,
+      phase: getSchedulePhaseByDateTimeIndex(dateTimeIndex),
+    };
+  });
 
 export const SCHEDULE_ROLE_DATA = [
   {

--- a/nextjs-app/constants/schedules.tsx
+++ b/nextjs-app/constants/schedules.tsx
@@ -4,15 +4,11 @@ import {
   IScheduleStep,
   ScheduleType,
 } from "@/types/schedule";
-import { getSchedulePhaseByDateTimeIndex } from "@/utils/schedule";
+import { getSchedulePhaseByMonth } from "@/utils/schedule";
 
-type IScheduleDetailWithoutPhase = Omit<IScheduleDetail, "phase"> & {
-  dateTimeIndex: number[];
-};
-
-const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
+export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] = [
   {
-    dateTimeIndex: [2, 3],
+    phase: getSchedulePhaseByMonth({ startMonth: 2, endMonth: 3 }),
     type: ScheduleType.DEFAULT,
     timeline: {
       title: "2月 - 3月",
@@ -30,10 +26,10 @@ const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
     },
   },
   {
-    dateTimeIndex: [3],
+    phase: getSchedulePhaseByMonth({ startMonth: 3, endMonth: 3 }),
     type: ScheduleType.DEFAULT,
     timeline: {
-      title: "3 月",
+      title: "3月",
       description: "(面試複審)",
     },
     event: [
@@ -45,10 +41,10 @@ const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
     ],
   },
   {
-    dateTimeIndex: [4],
-    type: ScheduleType.DEFAULT,
+    phase: getSchedulePhaseByMonth({ startMonth: 4, endMonth: 4 }),
+    type: ScheduleType.HIGHLIGHT,
     timeline: {
-      title: "4 月",
+      title: "4月",
       description: "(面試複審)",
     },
     event: [
@@ -65,7 +61,7 @@ const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
     ],
   },
   {
-    dateTimeIndex: [5],
+    phase: getSchedulePhaseByMonth({ startMonth: 5, endMonth: 5 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "5月",
@@ -88,7 +84,7 @@ const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
     ],
   },
   {
-    dateTimeIndex: [6, 9],
+    phase: getSchedulePhaseByMonth({ startMonth: 6, endMonth: 9 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "6月 - 9月",
@@ -103,7 +99,7 @@ const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
     },
   },
   {
-    dateTimeIndex: [11],
+    phase: getSchedulePhaseByMonth({ startMonth: 11, endMonth: 11 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "11月",
@@ -118,19 +114,9 @@ const SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW: IScheduleDetailWithoutPhase[] = [
   },
 ];
 
-export const SCHEDULE_DETAIL_DATA_NAVIGATOR: IScheduleDetail[] =
-  SCHEDULE_DETAIL_DATA_NAVIGATOR_RAW.map((detail) => {
-    const { dateTimeIndex, ...scheduleDetail } = detail;
-
-    return {
-      ...scheduleDetail,
-      phase: getSchedulePhaseByDateTimeIndex(dateTimeIndex),
-    };
-  });
-
-const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
+export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] = [
   {
-    dateTimeIndex: [2, 3],
+    phase: getSchedulePhaseByMonth({ startMonth: 2, endMonth: 3 }),
     type: ScheduleType.DEFAULT,
     timeline: {
       title: "2月 - 3月",
@@ -148,7 +134,7 @@ const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
     },
   },
   {
-    dateTimeIndex: [4],
+    phase: getSchedulePhaseByMonth({ startMonth: 4, endMonth: 4 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "4月",
@@ -163,7 +149,7 @@ const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
     ],
   },
   {
-    dateTimeIndex: [5],
+    phase: getSchedulePhaseByMonth({ startMonth: 5, endMonth: 5 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "5月",
@@ -186,7 +172,7 @@ const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
     ],
   },
   {
-    dateTimeIndex: [6, 9],
+    phase: getSchedulePhaseByMonth({ startMonth: 6, endMonth: 9 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "6月 - 9月",
@@ -201,7 +187,7 @@ const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
     },
   },
   {
-    dateTimeIndex: [11],
+    phase: getSchedulePhaseByMonth({ startMonth: 11, endMonth: 11 }),
     type: ScheduleType.HIGHLIGHT,
     timeline: {
       title: "11月",
@@ -215,16 +201,6 @@ const SCHEDULE_DETAIL_DATA_SAILOR_RAW: IScheduleDetailWithoutPhase[] = [
     },
   },
 ];
-
-export const SCHEDULE_DETAIL_DATA_SAILOR: IScheduleDetail[] =
-  SCHEDULE_DETAIL_DATA_SAILOR_RAW.map((detail) => {
-    const { dateTimeIndex, ...scheduleDetail } = detail;
-
-    return {
-      ...scheduleDetail,
-      phase: getSchedulePhaseByDateTimeIndex(dateTimeIndex),
-    };
-  });
 
 export const SCHEDULE_ROLE_DATA = [
   {

--- a/nextjs-app/utils/schedule.ts
+++ b/nextjs-app/utils/schedule.ts
@@ -1,0 +1,30 @@
+import { SchedulePhase } from "@/types/schedule";
+
+const getCurrentMonthInTaipei = (now: Date): number =>
+  Number(
+    now.toLocaleDateString("en-US", {
+      month: "numeric",
+      timeZone: "Asia/Taipei",
+    })
+  );
+
+export const getSchedulePhaseByDateTimeIndex = (
+  dateTimeIndex: number[],
+  now = new Date()
+): SchedulePhase => {
+  const currentMonth = getCurrentMonthInTaipei(now);
+  const validMonths = dateTimeIndex.filter(
+    (month) => Number.isInteger(month) && month >= 1 && month <= 12
+  );
+
+  if (validMonths.length === 0) {
+    throw new Error("dateTimeIndex should include at least one month between 1 and 12");
+  }
+
+  const start = Math.min(...validMonths);
+  const end = Math.max(...validMonths);
+
+  if (currentMonth < start) return SchedulePhase.ACTIVE;
+  if (currentMonth > end) return SchedulePhase.EXPIRED;
+  return SchedulePhase.ONGOING;
+};

--- a/nextjs-app/utils/schedule.ts
+++ b/nextjs-app/utils/schedule.ts
@@ -8,23 +8,19 @@ const getCurrentMonthInTaipei = (now: Date): number =>
     })
   );
 
-export const getSchedulePhaseByDateTimeIndex = (
-  dateTimeIndex: number[],
-  now = new Date()
+export const getSchedulePhaseByMonth = (
+  {
+    startMonth,
+    endMonth,
+  }: {
+    startMonth: number;
+    endMonth: number;
+  },
 ): SchedulePhase => {
+  const now = new Date();
   const currentMonth = getCurrentMonthInTaipei(now);
-  const validMonths = dateTimeIndex.filter(
-    (month) => Number.isInteger(month) && month >= 1 && month <= 12
-  );
 
-  if (validMonths.length === 0) {
-    throw new Error("dateTimeIndex should include at least one month between 1 and 12");
-  }
-
-  const start = Math.min(...validMonths);
-  const end = Math.max(...validMonths);
-
-  if (currentMonth < start) return SchedulePhase.ACTIVE;
-  if (currentMonth > end) return SchedulePhase.EXPIRED;
+  if (currentMonth < startMonth) return SchedulePhase.ACTIVE;
+  if (currentMonth > endMonth) return SchedulePhase.EXPIRED;
   return SchedulePhase.ONGOING;
 };

--- a/nextjs-app/utils/schedule.ts
+++ b/nextjs-app/utils/schedule.ts
@@ -1,26 +1,40 @@
 import { SchedulePhase } from "@/types/schedule";
 
-const getCurrentMonthInTaipei = (now: Date): number =>
-  Number(
-    now.toLocaleDateString("en-US", {
-      month: "numeric",
-      timeZone: "Asia/Taipei",
-    })
-  );
+const CURRENT_YEAR = 2026;
+
+const getCurrentDate = (now: Date): {
+  year: number;
+  month: number;
+} => {
+  const date = now.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "numeric",
+    timeZone: "Asia/Taipei",
+  });
+  const [monthString, yearString] = date.split("/");
+  
+  return {
+    year: Number(yearString),
+    month: Number(monthString),
+  };
+};
 
 export const getSchedulePhaseByMonth = (
   {
+    year = CURRENT_YEAR,
     startMonth,
     endMonth,
   }: {
+    year?: number;
     startMonth: number;
     endMonth: number;
   },
 ): SchedulePhase => {
   const now = new Date();
-  const currentMonth = getCurrentMonthInTaipei(now);
+  const currentDate = getCurrentDate(now);
+  if (currentDate.year > year) return SchedulePhase.EXPIRED;
 
-  if (currentMonth < startMonth) return SchedulePhase.ACTIVE;
-  if (currentMonth > endMonth) return SchedulePhase.EXPIRED;
+  if (currentDate.month < startMonth) return SchedulePhase.ACTIVE;
+  if (currentDate.month > endMonth) return SchedulePhase.EXPIRED;
   return SchedulePhase.ONGOING;
 };


### PR DESCRIPTION
## Why need this change? / Root cause:
related issue: [[活動辦法][報名流程] 小船要漂在當月份](https://www.notion.so/32f3af684bf8807ca906f221563605af)


## Changes made:
- create `utils/schedule` file
- add `getSchedulePhaseByMonth` function to determine the position of the boat automatically
- change one event to correct month section in navigator(水手) tab

<img width="919" height="972" alt="截圖 2026-03-30 晚上9 08 51" src="https://github.com/user-attachments/assets/23d6e22b-6f1f-4f32-9d9f-cfb94a9261ce" />
<img width="935" height="921" alt="截圖 2026-03-30 晚上9 08 58" src="https://github.com/user-attachments/assets/7801b36a-e65e-455f-a9a5-f29e74a8c60e" />


## Test Scope / Change impact:
`/program-rules` / Medium

