### PR TITLE
feat: add session schema in sanity

### DIFF
--- a/nextjs-app/sanity/lib/queries.ts
+++ b/nextjs-app/sanity/lib/queries.ts
@@ -121,3 +121,15 @@ export const allActivitiesQuery = defineQuery(`*[_type == "activity"]{
     href
   }
 }`);
+
+export const staffQuery = defineQuery(`
+  *[_type == "staff" && isVisible == true] {
+    _id,
+    name,
+    title,
+    subTitle,
+    team,
+    quote,
+    "imageUrl": imageUrl.asset->url,
+  }
+`);

--- a/studio/src/schemaTypes/documents/session.ts
+++ b/studio/src/schemaTypes/documents/session.ts
@@ -1,0 +1,43 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'session',
+  title: 'Session',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'session',
+      type: 'number',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'year',
+      type: 'number',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'staff',
+      title: 'Staff List',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'reference',
+          to: [{ type: 'staff' }],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Published', value: 'published'},
+          {title: 'Draft', value: 'draft'},
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'draft',
+    }),
+  ],
+})

--- a/studio/src/schemaTypes/documents/staff.ts
+++ b/studio/src/schemaTypes/documents/staff.ts
@@ -1,0 +1,59 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'staff',
+  title: 'Staff',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'team',
+      title: 'Team',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'BD', value: 'BD'},
+          {title: 'Data', value: 'Data'},
+          {title: 'Engineer', value: 'Engineer'},
+          {title: 'MKT', value: 'MKT'},
+          {title: 'PM', value: 'PM'},
+          {title: 'UIUX', value: 'UIUX'},
+          {title: 'Leadership', value: 'Leadership'},
+        ],
+      },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+    defineField({
+      name: 'subTitle',
+      title: 'Sub Title',
+      type: 'array',
+      of: [{type: 'string'}],
+    }),
+    defineField({
+      name: 'quote',
+      title: 'Quote',
+      type: 'string',
+    }),
+    defineField({
+      name: 'imageUrl',
+      title: 'Image Url',
+      type: 'image',
+    }),
+    defineField({
+      name: 'isVisible',
+      title: 'Is Visible',
+      type: 'boolean',
+      initialValue: true,
+      validation: (rule) => rule.required(),
+    }),
+  ],
+})

--- a/studio/src/schemaTypes/index.ts
+++ b/studio/src/schemaTypes/index.ts
@@ -5,12 +5,15 @@ import faq from './documents/faq'
 import faqCategory from './documents/faqCategory'
 import activity from './documents/activity'
 import activityCategory from './documents/activityCategory'
+import staff from './documents/staff'
 import callToAction from './objects/callToAction'
 import infoSection from './objects/infoSection'
 import settings from './singletons/settings'
 import link from './objects/link'
 import blockContent from './objects/blockContent'
 import timeRange from './objects/timeRange'
+import session from './documents/session'
+
 // Export an array of all the schema types.  This is used in the Sanity Studio configuration. https://www.sanity.io/docs/schema-types
 
 export const schemaTypes = [
@@ -24,6 +27,8 @@ export const schemaTypes = [
   faqCategory,
   activity,
   activityCategory,
+  staff,
+  session,
   // Objects
   blockContent,
   infoSection,


### PR DESCRIPTION
## Why need this change? 
Related issus: [US-02｜建立「屆別」Schema](https://www.notion.so/US-02-Schema-3233af684bf8804bbc03c0aa572c6137?source=copy_link)

## Changes made:
- add `session` and `staff` schema


## Test Scope / Change impact:
- team page
- Medium
