### PR TITLE
feat: staff name + quote no required

### DIFF
--- a/nextjs-app/sanity/lib/queries.ts
+++ b/nextjs-app/sanity/lib/queries.ts
@@ -127,8 +127,7 @@ export const staffQuery = defineQuery(`
     _id in *[_type == "session" && status == "published"].staff[]._ref
   ] {
     _id,
-    nameZh,
-    nameEn,
+    name,
     role,
     team,
     quote,

--- a/studio/src/schemaTypes/documents/staff.ts
+++ b/studio/src/schemaTypes/documents/staff.ts
@@ -75,12 +75,13 @@ export default defineType({
     defineField({
       name: 'session',
       title: '屆次',
-      type: 'array',
-      of: [
-        { type: 'reference', to: [{ type: 'session' }] }
-      ],
-      description: '此工作人員參與的屆次，可複選',
-      validation: (rule) => rule.required().min(1),
+      type: 'reference',
+      to: [{ type: 'session' }],
+      options: {
+        layout: 'dropdown',
+      },
+      description: '此工作人員參與的屆次',
+      validation: (rule) => rule.required(),
     }),
   ],
   // 預覽設定：在 Studio 列表中顯示姓名與角色

--- a/studio/src/schemaTypes/documents/staff.ts
+++ b/studio/src/schemaTypes/documents/staff.ts
@@ -6,17 +6,10 @@ export default defineType({
   type: 'document',
   fields: [
     defineField({
-      name: 'nameZh',
-      title: '中文姓名',
+      name: 'name',
+      title: '姓名',
       type: 'string',
-      description: '工作人員的中文姓名',
-      validation: (rule) => rule.required(),
-    }),
-    defineField({
-      name: 'nameEn',
-      title: '英文姓名',
-      type: 'string',
-      description: '工作人員的英文姓名',
+      description: '工作人員的顯示姓名',
       validation: (rule) => rule.required(),
     }),
     defineField({
@@ -69,7 +62,7 @@ export default defineType({
       type: 'text',
       description: '一句話介紹自己，最多 200 字',
       rows: 3,
-      validation: (rule) => rule.required().max(200),
+      validation: (rule) => rule.max(200),
     }),
     defineField({
       name: 'isVisible',
@@ -83,7 +76,7 @@ export default defineType({
   // 預覽設定：在 Studio 列表中顯示姓名與角色
   preview: {
     select: {
-      title: 'nameZh',
+      title: 'name',
       role: 'role',
       team: 'team',
       media: 'photo',

--- a/studio/src/schemaTypes/documents/staff.ts
+++ b/studio/src/schemaTypes/documents/staff.ts
@@ -72,6 +72,16 @@ export default defineType({
       initialValue: true,
       validation: (rule) => rule.required(),
     }),
+    defineField({
+      name: 'session',
+      title: '屆次',
+      type: 'array',
+      of: [
+        { type: 'reference', to: [{ type: 'session' }] }
+      ],
+      description: '此工作人員參與的屆次，可複選',
+      validation: (rule) => rule.required().min(1),
+    }),
   ],
   // 預覽設定：在 Studio 列表中顯示姓名與角色
   preview: {


### PR DESCRIPTION
## Why need this change? / Root cause:
- [US-01｜建立工作人員 Schema ](https://www.notion.so/US-01-Schema-3233af684bf880809d31ee81530769d5)

-

## Changes made:
1. 因為第八屆工作人員提供的名字有的只有中文姓名或只有英文姓名

移除 nameZh / nameEn，改成必填 name

<img width="2546" height="1284" alt="image" src="https://github.com/user-attachments/assets/dc645de8-b539-48fc-8fa0-363ca6c454b4" />

3. 因為第八屆工作人員沒有提供個人名言

quote 改為非必填

<img width="1778" height="1260" alt="image" src="https://github.com/user-attachments/assets/2c1b0d20-5746-4320-8fb8-43e0dc3546c5" />


-

## Test Scope / Change impact:

- sanity

