### PR TITLE
fix: 將 staff team 欄位改為選填並處理無組別的顯示

### DIFF
--- a/nextjs-app/components/common/ProfileCard.tsx
+++ b/nextjs-app/components/common/ProfileCard.tsx
@@ -6,7 +6,7 @@ import HashTag from "./HashTag";
 import type { FC } from "react";
 
 interface IProfileCardProps {
-  team?: string | null;
+  team: Team | null;
   name: string;
   title?: string;
   subTitle?: string[];
@@ -27,15 +27,8 @@ const ProfileCard: FC<IProfileCardProps> = ({
   hasBorder = false,
 }) => {
   const hasTags = hashTags.length > 0;
-  const validTeam =
-    team && (Object.values(Team) as string[]).includes(team)
-      ? (team as Team)
-      : null;
-  const teamInfo = team
-    ? validTeam
-      ? teamDisplayTextMap[validTeam]
-      : { zhGroupName: team, enGroupName: team }
-    : null;
+  const teamInfo = team ? teamDisplayTextMap[team] : null;
+  const { zhGroupName = "", enGroupName = "", shortName } = teamInfo ?? {};
 
   return (
     <div
@@ -44,14 +37,12 @@ const ProfileCard: FC<IProfileCardProps> = ({
         hasBorder && "border-[1px] border-yellow-6"
       )}
     >
-      {teamInfo && (
+      {(zhGroupName || enGroupName) && (
         <div>
-          <p className="text-neutral-10 text-h5">
-            <span>{teamInfo.zhGroupName}</span>
-          </p>
+          <p className="text-neutral-10 text-h5">{zhGroupName}</p>
           <p className="text-neutral-10 text-subtitle-lg">
-            <span>{teamInfo.enGroupName}</span>
-            {teamInfo.shortName && <span> ({teamInfo.shortName})</span>}
+            {enGroupName}
+            {shortName && <span> ({shortName})</span>}
           </p>
         </div>
       )}

--- a/nextjs-app/components/common/ProfileCard.tsx
+++ b/nextjs-app/components/common/ProfileCard.tsx
@@ -6,7 +6,7 @@ import HashTag from "./HashTag";
 import type { FC } from "react";
 
 interface IProfileCardProps {
-  team: string;
+  team?: string | null;
   name: string;
   title?: string;
   subTitle?: string[];
@@ -27,13 +27,15 @@ const ProfileCard: FC<IProfileCardProps> = ({
   hasBorder = false,
 }) => {
   const hasTags = hashTags.length > 0;
-  const validTeam = (Object.values(Team) as string[]).includes(team)
-    ? (team as Team)
+  const validTeam =
+    team && (Object.values(Team) as string[]).includes(team)
+      ? (team as Team)
+      : null;
+  const teamInfo = team
+    ? validTeam
+      ? teamDisplayTextMap[validTeam]
+      : { zhGroupName: team, enGroupName: team }
     : null;
-  const teamInfo = validTeam
-    ? teamDisplayTextMap[validTeam]
-    : { zhGroupName: team, enGroupName: team };
-  const { zhGroupName, enGroupName, shortName } = teamInfo;
 
   return (
     <div
@@ -42,15 +44,17 @@ const ProfileCard: FC<IProfileCardProps> = ({
         hasBorder && "border-[1px] border-yellow-6"
       )}
     >
-      <div>
-        <p className="text-neutral-10 text-h5">
-          <span>{zhGroupName}</span>
-        </p>
-        <p className="text-neutral-10 text-subtitle-lg">
-          <span>{enGroupName}</span>
-          {shortName && <span> ({shortName})</span>}
-        </p>
-      </div>
+      {teamInfo && (
+        <div>
+          <p className="text-neutral-10 text-h5">
+            <span>{teamInfo.zhGroupName}</span>
+          </p>
+          <p className="text-neutral-10 text-subtitle-lg">
+            <span>{teamInfo.enGroupName}</span>
+            {teamInfo.shortName && <span> ({teamInfo.shortName})</span>}
+          </p>
+        </div>
+      )}
 
       <div className="px-2">
         <div className="w-full aspect-square rounded-circle relative overflow-hidden">

--- a/nextjs-app/types/team.ts
+++ b/nextjs-app/types/team.ts
@@ -5,7 +5,7 @@ export type Staff = {
   _id: string;
   name: string;
   role: ExecutionGroupType;
-  team: Team;
+  team: Team | null;
   quote: string | null;
   photo: string;
   title: string | null;

--- a/studio/src/schemaTypes/documents/staff.ts
+++ b/studio/src/schemaTypes/documents/staff.ts
@@ -79,7 +79,6 @@ export default defineType({
         ],
         layout: 'dropdown',
       },
-      validation: (rule) => rule.required(),
     }),
     defineField({
       name: 'quote',


### PR DESCRIPTION
---
  Why need this change? / Root cause:

  - 部分工作人員（尤其是歷史屆次）可能不隸屬於特定職能組別，原本 team 欄位為必填，導致這類資料無法在 Sanity Studio 中正常儲存

  Changes made:

  - Sanity schema (studio/src/schemaTypes/documents/staff.ts)：移除 team 欄位的 required() 驗證，改為選填
  - 型別 (nextjs-app/types/team.ts)：Staff.team 從 Team 改為 Team | null
  - ProfileCard (nextjs-app/components/common/ProfileCard.tsx)：team prop 改為 string | null | undefined，無組別資料時條件性隱藏組別區塊，避免渲染空白

  Test Scope / Change impact:

  - 已有 team 資料的工作人員：顯示不受影響
  - 無 team 資料的工作人員：ProfileCard 正常顯示，組別區塊不渲染
  - /about/team 頁面篩選、排序邏輯不受影響（排序已有 null-safe 處理）
  - 計畫頁船長卡片（Captains）不受影響