### PR TITLE
feat: 新增團隊類別及其顯示名稱

### DIFF
--- a/nextjs-app/components/pages/main/WhoWeAre.tsx
+++ b/nextjs-app/components/pages/main/WhoWeAre.tsx
@@ -124,6 +124,18 @@ const teamDisplayTextMap: Record<Team, { name: string; fullName: string }> = {
     name: "UIUX",
     fullName: "User Interface & Experience",
   },
+  [Team.ENTREPRENEURSHIP]: {
+    name: "Entrepreneurship",
+    fullName: "Entrepreneurship",
+  },
+  [Team.MARTECH]: {
+    name: "Martech",
+    fullName: "Marketing Technology",
+  },
+  [Team.OPERATION]: {
+    name: "Operation",
+    fullName: "Operation",
+  },
 };
 
 const WhoWeAre: FC = () => {

--- a/nextjs-app/constants/team-display-text-map.ts
+++ b/nextjs-app/constants/team-display-text-map.ts
@@ -41,4 +41,21 @@ export const teamDisplayTextMap: Record<
     zhGroupName: "領導力小學堂",
     enGroupName: "Leadership Academy",
   },
+  [Team.ENTREPRENEURSHIP]: {
+    zhGroupName: "創業",
+    enGroupName: "Entrepreneurship",
+  },
+  [Team.MARTECH]: {
+    zhGroupName: "行銷科技",
+    enGroupName: "Marketing Technology",
+    shortName: "Martech",
+  },
+  [Team.OPERATION]: {
+    zhGroupName: "營運",
+    enGroupName: "Operation",
+  },
+  [Team.LEADERSHIP_LEGACY]: {
+    zhGroupName: "領導力小學堂",
+    enGroupName: "Leadership Academy",
+  },
 };

--- a/nextjs-app/constants/team-display-text-map.ts
+++ b/nextjs-app/constants/team-display-text-map.ts
@@ -54,8 +54,4 @@ export const teamDisplayTextMap: Record<
     zhGroupName: "營運",
     enGroupName: "Operation",
   },
-  [Team.LEADERSHIP_LEGACY]: {
-    zhGroupName: "領導力小學堂",
-    enGroupName: "Leadership Academy",
-  },
 };

--- a/nextjs-app/types/index.ts
+++ b/nextjs-app/types/index.ts
@@ -5,11 +5,10 @@ export enum Team {
   MKT = "MKT",
   PM = "PM",
   UIUX = "UIUX",
-  LEADERSHIP = "Leadership",
+  LEADERSHIP = "領導力小學堂",
   ENTREPRENEURSHIP = "Entrepreneurship",
   MARTECH = "Martech",
   OPERATION = "Operation",
-  LEADERSHIP_LEGACY = "領導力小學堂",
 }
 
 export enum Role {

--- a/nextjs-app/types/index.ts
+++ b/nextjs-app/types/index.ts
@@ -5,7 +5,7 @@ export enum Team {
   MKT = "MKT",
   PM = "PM",
   UIUX = "UIUX",
-  LEADERSHIP = "領導力小學堂",
+  LEADERSHIP = "Leadership",
   ENTREPRENEURSHIP = "Entrepreneurship",
   MARTECH = "Martech",
   OPERATION = "Operation",

--- a/nextjs-app/types/index.ts
+++ b/nextjs-app/types/index.ts
@@ -6,6 +6,10 @@ export enum Team {
   PM = "PM",
   UIUX = "UIUX",
   LEADERSHIP = "Leadership",
+  ENTREPRENEURSHIP = "Entrepreneurship",
+  MARTECH = "Martech",
+  OPERATION = "Operation",
+  LEADERSHIP_LEGACY = "領導力小學堂",
 }
 
 export enum Role {

--- a/studio/src/schemaTypes/documents/staff.ts
+++ b/studio/src/schemaTypes/documents/staff.ts
@@ -74,7 +74,7 @@ export default defineType({
           {title: 'BD', value: 'BD'},
           {title: 'Entrepreneurship (歷史組別)', value: 'Entrepreneurship'},
           {title: 'Martech (歷史組別)', value: 'Martech'},
-          {title: '領導力小學堂 (歷史組別)', value: '領導力小學堂'},
+          {title: '領導力小學堂 (歷史組別)', value: 'Leadership'},
           {title: 'Operation (歷史組別)', value: 'Operation'},
         ],
         layout: 'dropdown',


### PR DESCRIPTION
Why need this change? / Root cause:

  - 歷史屆次的工作人員資料帶有舊有組別值（Entrepreneurship、Martech、Operation、領導力小學堂），這些值不在 Team enum 中，導致 teamDisplayTextMap 無法對應顯示正確的組別名稱

  Changes made:

  - nextjs-app/types/index.ts：新增 4 個歷史組別至 Team enum（ENTREPRENEURSHIP、MARTECH、OPERATION、LEADERSHIP_LEGACY）
  - nextjs-app/constants/team-display-text-map.ts：補上對應的中英文顯示名稱

  Test Scope / Change impact:

  - 歷史屆次的工作人員卡片現在會正確顯示組別名稱，而非靜默隱藏
  - 現有組別顯示不受影響
  - teamDisplayTextMap 型別為 Record<Team, ...>，新增 enum 值後 TypeScript 會確保所有值都有對應的 map 項目